### PR TITLE
Correcting version numbers

### DIFF
--- a/docs/full-node/Full-Node-More.md
+++ b/docs/full-node/Full-Node-More.md
@@ -48,7 +48,7 @@ To fix the problem:
 
 1. Delete the folder .alephium `rm .alephium`
 
-2. Restart the node and wait for synchronization `java -jar alephium-1.3.2.jar`
+2. Restart the node and wait for synchronization `java -jar alephium-1.x.x.jar`
 
 ## Moving the Alephium data folder
 

--- a/docs/full-node/Full-Node-Starter-Guide.md
+++ b/docs/full-node/Full-Node-Starter-Guide.md
@@ -16,15 +16,15 @@ Ensure that Java (11 or 17 is recommended) is installed on your computer:
 
 ## Download Application File
 
-Download file `alephium-1.3.2.jar` from [Github release](https://github.com/alephium/alephium/releases/latest) (do not double click on it, it can not be launched this way).
+Download file `alephium-1.x.x.jar` from [Github release](https://github.com/alephium/alephium/releases/latest) (do not double click on it, it can not be launched this way).
 
 ## Start your node
 
 1. Open the search and type in `Terminal` (for Mac and Ubuntu) or `Command Prompt` (for Windows).
-2. In the Terminal/Command Prompt program, type `cd your-jar-file-path` to enter the folder in which the **alephium-1.3.2.jar** file is saved.
+2. In the Terminal/Command Prompt program, type `cd your-jar-file-path` to enter the folder in which the **alephium-1.x.x.jar** file is saved.
 3. Type the following command and press Enter to launch the full node:
    ```shell
-   java -jar alephium-1.3.2.jar
+   java -jar alephium-1.x.x.jar
    ```
 
 🎉 _**Tada, your node is running**_

--- a/docs/full-node/Full-node-on-raspberry-pi.md
+++ b/docs/full-node/Full-node-on-raspberry-pi.md
@@ -137,7 +137,7 @@ docker ps
 Now we can run the full node, in a single line, as follow:
 
 ```shell
-docker run -it --rm -p 12973:12973 --name alephium alephium/alephium:v1.3.2
+docker run -it --rm -p 12973:12973 --name alephium alephium/alephium:latest
 ```
 
 ### Docker-compose
@@ -152,7 +152,7 @@ start your full node from this definition.
 version: "3"
 services:
   broker:
-    image: "alephium/alephium:v1.3.2"
+    image: "alephium/alephium:latest"
     restart: unless-stopped
     ports:
       - 9973:9973/tcp

--- a/i18n/fr/docusaurus-plugin-content-docs/current/full-node/Full-Node-More.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/full-node/Full-Node-More.md
@@ -40,7 +40,7 @@ Pour résoudre le problème :
 
 1. Supprimez le dossier .alephium `rm .alephium`.
 
-2. Redémarrez le noeud et attendez la synchronisation `java -jar alephium-1.2.6.jar`.
+2. Redémarrez le noeud et attendez la synchronisation `java -jar alephium-1.x.x.jar`.
 
 ## Déplacer le dossier de données d'Alephium
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/full-node/Full-Node-Starter-Guide.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/full-node/Full-Node-Starter-Guide.md
@@ -16,15 +16,15 @@ Assurez-vous que Java (11 ou 17 est recommandé) est installé sur votre ordinat
 
 ## Télécharger le fichier d'application
 
-Téléchargez le fichier `alephium-1.2.6.jar` depuis [Github release](https://github.com/alephium/alephium/releases/latest) (ne double-cliquez pas dessus, il ne peut pas être lancé de cette façon).
+Téléchargez le fichier `alephium-1.x.x.jar` depuis [Github release](https://github.com/alephium/alephium/releases/latest) (ne double-cliquez pas dessus, il ne peut pas être lancé de cette façon).
 
 ## Démarrez votre noeud
 
 1. Ouvrez la recherche et tapez `Terminal` (pour Mac et Ubuntu) ou `Command Prompt` (pour Windows).
-2. Dans le programme Terminal/Command Prompt, tapez `cd your-jar-file-path` pour entrer dans le dossier dans lequel le fichier **alephium-1.2.6.jar** est enregistré.
+2. Dans le programme Terminal/Command Prompt, tapez `cd your-jar-file-path` pour entrer dans le dossier dans lequel le fichier **alephium-1.x.x.jar** est enregistré.
 3. Tapez la commande suivante et appuyez sur Entrée pour lancer le nœud complet :
    ```shell
-   java -jar alephium-1.2.6.jar
+   java -jar alephium-1.x.x.jar
    ```
 
 🎉 _**Tada, votre nœud est en cours d'exécution**_

--- a/i18n/fr/docusaurus-plugin-content-docs/current/full-node/Full-node-on-raspberry-pi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/full-node/Full-node-on-raspberry-pi.md
@@ -136,7 +136,7 @@ docker ps
 Maintenant, nous pouvons exécuter le noeud complet, en une seule ligne, comme suit :
 
 ```shell
-docker run -it --rm -p 12973:12973 --name alephium alephium/alephium:v1.2.6
+docker run -it --rm -p 12973:12973 --name alephium alephium/alephium:latest
 ```
 
 ### Docker-compose
@@ -150,7 +150,7 @@ Donc, ci-dessous est la définition du service que vous pouvez mettre dans un fi
 version: "3"
 services:
   broker:
-    image: "alephium/alephium:v1.2.6"
+    image: "alephium/alephium:latest"
     restart: unless-stopped
     ports:
       - 9973:9973/tcp


### PR DESCRIPTION
Changes all docker-compose occurences to use `:latest` and sets all version numbers of full node to `1.x.x`