### PR TITLE
Update endpoints with v16 and testnet migration

### DIFF
--- a/docs/dapps/api-aliases.json
+++ b/docs/dapps/api-aliases.json
@@ -2,93 +2,125 @@
     "current": [
         {
             "from": "https://wallet.mainnet.alephium.org",
-            "to": "https://wallet-v15.mainnet.alephium.org"
+            "to": "https://wallet-v16.mainnet.alephium.org"
         },
         {
             "from": "https://wallet.testnet.alephium.org",
-            "to": "https://wallet-v15.testnet.alephium.org"
+            "to": "https://wallet-v16.testnet.alephium.org"
         },
         {
             "from": "https://backend.mainnet.alephium.org",
-            "to": "https://backend-v111.mainnet.alephium.org"
+            "to": "https://backend-v112.mainnet.alephium.org"
         },
         {
             "from": "https://backend.testnet.alephium.org",
-            "to": "https://backend-v111.testnet.alephium.org"
+            "to": "https://backend-v112.testnet.alephium.org"
         },
         {
             "from": "https://explorer.mainnet.alephium.org",
-            "to": "https://explorer-v111.mainnet.alephium.org"
+            "to": "https://explorer-v112.mainnet.alephium.org"
         },
         {
             "from": "https://explorer.testnet.alephium.org",
-            "to": "https://explorer-v111.testnet.alephium.org"
+            "to": "https://explorer-v112.testnet.alephium.org"
+        },
+        {
+            "from": "https://explorer.alephium.org",
+            "to": "https://explorer-v112.mainnet.alephium.org"
+        },
+        {
+            "from": "https://testnet.alephium.org",
+            "to": "https://explorer-v112.testnet.alephium.org"
         }
     ],
     "deprecated": [
         {
+            "from": "https://wallet-v15.mainnet.alephium.org",
+            "to": "https://wallet-v16.mainnet.alephium.org"
+        },
+        {
+            "from": "https://wallet-v15.testnet.alephium.org",
+            "to": "https://wallet-v16.testnet.alephium.org"
+        },
+        {
             "from": "https://wallet-v18.mainnet.alephium.org",
-            "to": "https://wallet-v15.mainnet.alephium.org"
+            "to": "https://wallet-v16.mainnet.alephium.org"
         },
         {
             "from": "https://wallet-v18.testnet.alephium.org",
-            "to": "https://wallet-v15.testnet.alephium.org"
+            "to": "https://wallet-v16.testnet.alephium.org"
         },
         {
             "from": "https://wallet-v19.mainnet.alephium.org",
-            "to": "https://wallet-v15.mainnet.alephium.org"
+            "to": "https://wallet-v16.mainnet.alephium.org"
         },
         {
             "from": "https://wallet-v19.testnet.alephium.org",
-            "to": "https://wallet-v15.testnet.alephium.org"
+            "to": "https://wallet-v16.testnet.alephium.org"
         },
         {
             "from": "https://backend-v18.mainnet.alephium.org",
-            "to": "https://backend-v111.mainnet.alephium.org"
+            "to": "https://backend-v112.mainnet.alephium.org"
         },
         {
             "from": "https://backend-v18.testnet.alephium.org",
-            "to": "https://backend-v111.testnet.alephium.org"
+            "to": "https://backend-v112.testnet.alephium.org"
         },
         {
             "from": "https://backend-v19.mainnet.alephium.org",
-            "to": "https://backend-v111.mainnet.alephium.org"
+            "to": "https://backend-v112.mainnet.alephium.org"
         },
         {
             "from": "https://backend-v19.testnet.alephium.org",
-            "to": "https://backend-v111.testnet.alephium.org"
+            "to": "https://backend-v112.testnet.alephium.org"
         },
         {
             "from": "https://backend-v110.mainnet.alephium.org",
-            "to": "https://backend-v111.mainnet.alephium.org"
+            "to": "https://backend-v112.mainnet.alephium.org"
         },
         {
             "from": "https://backend-v110.testnet.alephium.org",
-            "to": "https://backend-v111.testnet.alephium.org"
+            "to": "https://backend-v112.testnet.alephium.org"
+        },
+        {
+            "from": "https://backend-v111.mainnet.alephium.org",
+            "to": "https://backend-v112.mainnet.alephium.org"
+        },
+        {
+            "from": "https://backend-v111.testnet.alephium.org",
+            "to": "https://backend-v112.testnet.alephium.org"
         },
         {
             "from": "https://explorer-v18.mainnet.alephium.org",
-            "to": "https://explorer-v111.mainnet.alephium.org"
+            "to": "https://explorer-v112.mainnet.alephium.org"
         },
         {
             "from": "https://explorer-v18.testnet.alephium.org",
-            "to": "https://explorer-v111.testnet.alephium.org"
+            "to": "https://explorer-v112.testnet.alephium.org"
         },
         {
             "from": "https://explorer-v19.mainnet.alephium.org",
-            "to": "https://explorer-v111.mainnet.alephium.org"
+            "to": "https://explorer-v112.mainnet.alephium.org"
         },
         {
             "from": "https://explorer-v19.testnet.alephium.org",
-            "to": "https://explorer-v111.testnet.alephium.org"
+            "to": "https://explorer-v112.testnet.alephium.org"
         },
         {
             "from": "https://explorer-v110.mainnet.alephium.org",
-            "to": "https://explorer-v111.mainnet.alephium.org"
+            "to": "https://explorer-v112.mainnet.alephium.org"
         },
         {
             "from": "https://explorer-v110.testnet.alephium.org",
-            "to": "https://explorer-v111.testnet.alephium.org"
+            "to": "https://explorer-v112.testnet.alephium.org"
+        },
+        {
+            "from": "https://explorer-v111.mainnet.alephium.org",
+            "to": "https://explorer-v112.mainnet.alephium.org"
+        },
+        {
+            "from": "https://explorer-v111.testnet.alephium.org",
+            "to": "https://explorer-v112.testnet.alephium.org"
         }
     ]
 }

--- a/docs/dapps/public-services.md
+++ b/docs/dapps/public-services.md
@@ -19,12 +19,10 @@ To receive testnet tokens, simply tweet `#alephium` followed by your wallet addr
 ## Node and Explorer APIs
 
 Currently, the following API services are maintained. Note that all APIs are rate limited to prevent spam.
-* `https://wallet-v15.mainnet.alephium.org` for mainnet with node v1.5.X ([Test](https://wallet-v15.mainnet.alephium.org/infos/version))
-* `https://wallet-v15.testnet.alephium.org` for testnet with node v1.5.X ([Test](https://wallet-v15.testnet.alephium.org/infos/version))
-* `https://wallet-v16.testnet.alephium.org` for testnet-v16 with node v1.6.X ([Test](https://wallet-v16.testnet.alephium.org/infos/version))
-* `https://backend-v111.mainnet.alephium.org` for mainnet with explorer backend v1.11.X ([Test](https://backend-v111.mainnet.alephium.org/infos))
-* `https://backend-v111.testnet.alephium.org` for testnet with explorer backend v1.11.X ([Test](https://backend-v111.testnet.alephium.org/infos))
-* `https://backend-v112.testnet.alephium.org` for testnet-v16 with explorer backend v1.12.X ([Test](https://backend-v112.testnet.alephium.org/infos))
+* `https://wallet-v16.mainnet.alephium.org` for mainnet with node v1.6.X ([Test](https://wallet-v16.mainnet.alephium.org/infos/version))
+* `https://wallet-v16.testnet.alephium.org` for testnet with node v1.6.X ([Test](https://wallet-v16.testnet.alephium.org/infos/version))
+* `https://backend-v112.mainnet.alephium.org` for mainnet with explorer backend v1.12.X ([Test](https://backend-v112.mainnet.alephium.org/infos))
+* `https://backend-v112.testnet.alephium.org` for testnet with explorer backend v1.12.X ([Test](https://backend-v112.testnet.alephium.org/infos))
 
 As the project is still under active development, all APIs are versioned. Typically, only the latest versions are maintained, but any API upgrades will be announced to the community in advance.
 


### PR DESCRIPTION
Merge this only with the migration is effective.

This PR updates the doc to reflect the exact state of the endpoints for both mainnet and testnet.