### PR TITLE
update all Alephium discord links

### DIFF
--- a/docs/5min-overview.md
+++ b/docs/5min-overview.md
@@ -238,7 +238,7 @@ You will find the complete list of internationalized channel [here](./misc/Inter
 [whitepaper]: https://github.com/alephium/white-paper
 [tokenomics-medium]: https://medium.com/@alephium/tokenomics-of-alephium-61d59b51029c
 [website]: https://alephium.org/
-[discord]: https://discord.gg/JErgRBfRSB
+[discord]: https://alephium.org/discord
 [telegram]: https://t.me/alephiumgroup
 [twitter]: https://twitter.com/alephium
 [linkedin]: https://www.linkedin.com/company/alephium
@@ -256,7 +256,7 @@ You will find the complete list of internationalized channel [here](./misc/Inter
 [web3-sdk]: https://github.com/alephium/alephium-web3
 [wiki]: https://github.com/alephium/wiki
 [awesome]: https://github.com/alephium/awesome-alephium
-[mining-discord]: https://discord.gg/53QSMpKZyR
+[mining-discord]: https://alephium.org/discord
 [miner-starter-pack]: https://github.com/alephium/alephium-miner-getting-started
 [solo-mining-video]: https://www.youtube.com/watch?v=hdPH6inWjhc
 [reddit]: https://www.reddit.com/r/Alephium/

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -17,7 +17,7 @@ Before diving in deeper, we recommend that you check the following resources as 
 
 - [Official Website](https://alephium.org)
 - [Official Twitter](https://twitter.com/alephium)
-- [Official Discord](https://discord.gg/JErgRBfRSB)
+- [Official Discord](https://alephium.org/discord)
 - [Official Telegram](https://t.me/alephiumgroup)
 - [Official Reddit](https://reddit.com/r/Alephium)
 - [Official Medium](https://medium.com/@alephium), specifically:
@@ -117,7 +117,7 @@ Currently, 120 confirmations are needed for deposits, which is around 2hours (12
 
 ### When Binance?
 
-We are working toward additional listings and working our way up towards Binance. You will be among the first to know by joining the [Telegram group](https://t.me/alephiumgroup), the [Alephium Discord](https://discord.gg/JErgRBfRSB) or if you follow our [Twitter account](https://twitter.com/alephium).
+We are working toward additional listings and working our way up towards Binance. You will be among the first to know by joining the [Telegram group](https://t.me/alephiumgroup), the [Alephium Discord](https://alephium.org/discord) or if you follow our [Twitter account](https://twitter.com/alephium).
 
 ### What is your token ticker?
 
@@ -265,7 +265,7 @@ Automatic address discovery will be added in the near future. That way, when res
 
 ### What's new?
 
-You can check our announcement channels on Telegram or Discord. We also have developments update every week on [Discord](https://discord.gg/GxfzPBKJcy), [Reddit](https://www.reddit.com/r/Alephium/search?q=flair_name%3A%22Development%22&restrict_sr=1) & [Twitter](https://twitter.com/alephium).
+You can check our announcement channels on Telegram or Discord. We also have developments update every week on [Discord](https://alephium.org/discord), [Reddit](https://www.reddit.com/r/Alephium/search?q=flair_name%3A%22Development%22&restrict_sr=1) & [Twitter](https://twitter.com/alephium).
 
 ### Why is the project named Alephium?
 

--- a/docs/Leman Network Upgrade.md
+++ b/docs/Leman Network Upgrade.md
@@ -66,7 +66,7 @@ The Front End gets a complete revamp of everything + new tools! https://medium.c
 *Coming soon:* Test the next versions of the wallets
 :::
 
-Got questions? Join our discord https://discord.gg/h7cXXy4FEY
+Got questions? Join our [Discord](https://alephium.org/discord)
 
 ## Foundations for bridging to other chains
 

--- a/docs/mining/pool-mining-guide.md
+++ b/docs/mining/pool-mining-guide.md
@@ -37,7 +37,7 @@ alephium.api.api-key = "<api key>"
 
 ### ⚠️ Disclaimer
 
-This is a non-exhaustive list of mining-pools that are driven by the community. These pools are in no way endorsed by Alephium and Alephium cannot be held responsible for your choice of Pool. While the pools listed here have behaved as expected so far, keep in mind that choosing a pool requires you to do some research regarding the security, reputation and general safety of the pool. A good place to start is to [ask the community on the Discord](https://discord.gg/JErgRBfRSB)
+This is a non-exhaustive list of mining-pools that are driven by the community. These pools are in no way endorsed by Alephium and Alephium cannot be held responsible for your choice of Pool. While the pools listed here have behaved as expected so far, keep in mind that choosing a pool requires you to do some research regarding the security, reputation and general safety of the pool. A good place to start is to [ask the community on the Discord](https://alephium.org/discord)
 
 ### Using pools and how to get support
 
@@ -127,7 +127,7 @@ Below is a list of mining pools in alphabetic order. We encourage you to [send a
 ### Alephium GPU-Miner
 
 - Download: [https://github.com/alephium/gpu-miner](https://github.com/alephium/gpu-miner)
-- Support: [https://discord.gg/JErgRBfRSB](https://discord.gg/JErgRBfRSB)
+- Support: [https://alephium.org/discord](https://alephium.org/discord)
 
 ### bzMiner
 

--- a/docs/mining/solo-mining-guide.md
+++ b/docs/mining/solo-mining-guide.md
@@ -84,7 +84,7 @@ Alternatively, you could run the gpu-miner with docker by following the document
 
 Please follow the instructions on [https://github.com/alephium/amd-miner](https://github.com/alephium/amd-miner#readme) to run the gpu miner for AMD GPUs. Note that the performance of AMD miner is not in par with Nvidia miner.
 
-If you have any questions, feel free to reach out to the developers on [Discord](https://discord.gg/JErgRBfRSB).
+If you have any questions, feel free to reach out to the developers on [Discord](https://alephium.org/discord).
 
 ## More info on miner wallet
 

--- a/docs/misc/internationalization-and-localization.md
+++ b/docs/misc/internationalization-and-localization.md
@@ -12,7 +12,7 @@ import UntranslatedPageText from "@site/src/components/UntranslatedPageText";
 
 ## Discord
 
-Find the following languages in [the official Discord](https://discord.gg/JErgRBfRSB)
+Find the following languages in [the official Discord](https://alephium.org/discord)
 
 - AR 🌙العربية
 - CN 🐼 中文

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -68,7 +68,7 @@ const config = {
             items: [
               {
                 label: "Discord",
-                href: "https://discord.gg/JErgRBfRSB",
+                href: "https://alephium.org/discord",
                 postion: "left",
               },
               {

--- a/i18n/fr/docusaurus-plugin-content-docs/current/5min-overview.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/5min-overview.md
@@ -127,7 +127,7 @@ Rencontrez le reste de l'équipe sur notre site web ou sur Linkedin : <https://w
 
 ### Echangez avec nous
 
-- [Discord](https://discord.gg/JErgRBfRSB)
+- [Discord](https://alephium.org/discord)
 - [Telegram](https://t.me/alephiumgroup)
 - [Reddit](https://www.reddit.com/r/Alephium)
 
@@ -196,7 +196,7 @@ Venez commiter et faire une pull request avec nous : <https://github.com/alephiu
 
 ## Si vous êtes un mineur, commencez ici !
 
-Commencez par rejoindre le canal dédié aux mineurs sur discord : <https://discord.gg/53QSMpKZyR>
+Commencez par rejoindre le canal dédié aux mineurs sur discord : <https://alephium.org/discord>
 
 Trouvez notre pack de démarrage pour miner sur Github : <https://github.com/alephium/alephium-miner-getting-started>
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/misc/internationalization-and-localization.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/misc/internationalization-and-localization.md
@@ -5,7 +5,7 @@ title: Internationalisation et localisation (i18n)
 
 ## Discord
 
-Trouvez les différentes langues [sur le Discord officiel](https://discord.gg/JErgRBfRSB)
+Trouvez les différentes langues [sur le Discord officiel](https://alephium.org/discord)
 
 - AR 🌙العربية
 - CN 🐼 中文

--- a/i18n/fr/docusaurus-theme-classic/footer.json
+++ b/i18n/fr/docusaurus-theme-classic/footer.json
@@ -13,7 +13,7 @@
   },
   "link.item.label.Discord": {
     "message": "Discord",
-    "description": "The label of footer link with label=Discord linking to https://discord.gg/JErgRBfRSB"
+    "description": "The label of footer link with label=Discord linking to https://alephium.org/discord"
   },
   "link.item.label.Telegram": {
     "message": "Telegram",


### PR DESCRIPTION
Make sure our doc uses `https://alephium.org/discord` for all internal discord invite links instead of the discord link that prone to expiration.