### PR TITLE
Feature/dapp getting start improve

### DIFF
--- a/docs/dapps/build-dapp-from-scratch.md
+++ b/docs/dapps/build-dapp-from-scratch.md
@@ -8,8 +8,6 @@ import UntranslatedPageText from "@site/src/components/UntranslatedPageText";
 
 <UntranslatedPageText />
 
-#Dapps Getting started
-
 This guide will explore the basics of creating an Alephium dApp project.
 
 Prerequisites:

--- a/docs/dapps/build-dapp-from-scratch.md
+++ b/docs/dapps/build-dapp-from-scratch.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 50
+sidebar_position: 15
 title: Build dApp from scratch
 sidebar_label: Build dApp from scratch
 ---

--- a/docs/dapps/build-dapp-from-scratch.md
+++ b/docs/dapps/build-dapp-from-scratch.md
@@ -1,0 +1,546 @@
+---
+sidebar_position: 50
+title: Build dApp from scratch
+sidebar_label: Build dApp from scratch
+---
+
+import UntranslatedPageText from "@site/src/components/UntranslatedPageText";
+
+<UntranslatedPageText />
+
+#Dapps Getting started
+
+This guide will explore the basics of creating an Alephium dApp project.
+
+Prerequisites:
+
+- Write code in [Typescript](https://www.typescriptlang.org/)
+- Operate in a [terminal](https://en.wikipedia.org/wiki/Terminal_emulator)
+- [nodejs](https://nodejs.org/en/) version >= 16 installed
+- `npm` version >= 8 installed
+
+## Create a new dApp project: Token Faucet
+
+In this tutorial we will write our first dApp: A token faucet.
+
+Create a new project folder and navigate into it:
+
+```sh
+mkdir alephium-faucet-tuto
+cd alephium-faucet-tuto
+```
+
+Let's now create a `contracts` folder where we'll store all our contracts:
+
+```sh
+mkdir contracts
+```
+
+Our first contract we'll be `token.ral` which can be found [here](https://github.com/alephium/nextjs-template/blob/main/contracts/token.ral). You can copy the whole file into your `contracts` folder.
+
+Let's inspect it, piece by piece:
+
+```rust
+import "std/token_interface"
+
+Contract TokenFaucet(
+    symbol: ByteVec,
+    name: ByteVec,
+    decimals: U256,
+    supply: U256,
+    mut balance: U256
+) implements IToken {
+```
+
+The first four fields will be immutable values that store the data required to serve our [IToken interface](https://github.com/alephium/alephium-web3/blob/master/packages/web3/std/token_interface.ral).
+`mut balance` is a mutable value that keeps track of how many tokens are left in this faucet.
+
+You can see that our contract emits an `event` and defines an `error` code. Read the following for more info on [events](https://wiki.alephium.org/ralph/getting-started#events) and [error handling](https://wiki.alephium.org/ralph/getting-started#error-handling).
+
+This is followed by 5 access methods for the different contract's arguments.
+
+The last method is where the magic happens:
+
+```rust
+@using(assetsInContract = true, updateFields = true)
+pub fn withdraw(amount: U256) -> () {
+    // Debug events can be helpful for error analysis
+    emit Debug(`The current balance is ${balance}`)
+
+    // Make sure the amount is valid
+    assert!(amount <= 2, ErrorCodes.InvalidWithdrawAmount)
+    // Functions postfixed with `!` are built-in functions.
+    transferTokenFromSelf!(callerAddress!(), selfTokenId!(), amount)
+    // Ralph does not allow underflow.
+    balance = balance - amount
+
+    // Emit the event defined earlier.
+    emit Withdraw(callerAddress!(), amount)
+}
+```
+
+With the `assert!` we make sure no one takes more than 2 tokens at the same time.  
+`transferTokenFromSelf` will actually perform the transfer of the tokens.  
+We update the `mut balance` field with the new balance. In the case of underflow, an error will be raised and the transaction won't be performed.
+`callerAddress!()` and `selfTokenId!()` are built-in functions, you can read more about them in our [built-in functions page](/ralph/built-in-functions).
+## Compile your contract
+
+The compiler needs to contact the full node in order to compile the contract, you'll need to use the right information defined while [creating your devnet](/full-node/devnet). If you haven't start it, now it's the time.
+We define the node URL using the following config file: `alephium.config.ts`. 
+Create this file in the root directory of your project and paste the following code:
+
+```typescript
+import { Configuration } from '@alephium/cli'
+
+export type Settings = {}
+
+const configuration: Configuration<Settings> = {
+  defaultNetwork: 'devnet',
+  networks: {
+    devnet: {
+      //Make sure the two values match what's in your devnet configuration
+      nodeUrl: 'http://localhost:22973',
+      networkId: 2
+    }
+  }
+}
+
+export default configuration
+```
+
+Now, let's compile:
+
+```sh
+npx @alephium/cli@latest compile
+```
+
+It may ask you for some confirmation to install the latest `@alephium/cli` package. Select yes to proceed.
+
+Once the above command succeeds, you will notice that a new folder called `artifacts` was created. It contains several files related to your contract. For example, `artifacts/ts/TokenFaucet.ts` produces lots of helper functions like `at`, `fetchState`, `call*`, etc, as well as many test functions.
+
+## Test your contract
+The SDK provides unit test functionalities, which call the contract by sending a transaction, but instead of changing the blockchain state, it returns the new contract state, transaction outputs, and events.
+
+Install the test framework:
+
+```sh
+npm install ts-jest @types/jest
+```
+
+You'll also need our `@alephium/web3` package:
+
+```sh
+npm install @alephium/web3 @alephium/web3-test
+```
+
+Create a `test` folder:
+
+```sh
+mkdir test
+```
+
+and create the `test/token.test.ts` minimalistic test file with the following contents:
+
+```typescript
+import { web3, Project, addressFromContractId } from '@alephium/web3'
+import { randomContractId, testAddress } from '@alephium/web3-test'
+import { TokenFaucet } from '../artifacts/ts'
+
+describe('unit tests', () => {
+  it('Withdraws 1 token from TokenFaucet', async () => {
+
+    // Use the correct host and port
+    web3.setCurrentNodeProvider('http://127.0.0.1:22973')
+    await Project.build()
+
+    let testContractId = randomContractId()
+    let testParams = {
+      // a random address that the test contract resides in the tests
+      address: addressFromContractId(testContractId),
+      // assets owned by the test contract before a test
+      initialAsset: { alphAmount: 10n ** 18n, tokens: [{ id: testContractId, amount: 10n }] },
+      // initial state of the test contract
+      initialFields: {
+        symbol: Buffer.from('TF', 'utf8').toString('hex'),
+        name: Buffer.from('TokenFaucet', 'utf8').toString('hex'),
+        decimals: 18n,
+        supply: 10n ** 18n,
+        balance: 10n
+      },
+      // arguments to test the target function of the test contract
+      testArgs: { amount: 1n },
+      // assets owned by the caller of the function
+      inputAssets: [{ address: testAddress, asset: { alphAmount: 10n ** 18n } }]
+    }
+
+    const testResult = await TokenFaucet.testWithdrawMethod(testParams)
+    console.log(testResult)
+  })
+})
+```
+
+A more complex test can be found in our [alephium/nextjs-template](https://github.com/alephium/nextjs-template/blob/main/test/token.test.ts) project.
+
+Without entering too much into details, TypeScript needs some configuration to run the test so just create a file called `tsconfig.json` in the root directory of your project and paste the following code:
+
+```json
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "target": "es2020",
+    "esModuleInterop": true,
+    "module": "commonjs",
+    "resolveJsonModule": true
+  },
+  "exclude": ["node_modules"],
+  "include": ["src/**/*.ts", "test/**/*.ts", "scripts/**/*.ts", "alephium.config.ts", "artifacts/**/*.ts"]
+}
+```
+
+You can now run the test:
+
+```sh
+npx @alephium/cli@latest test
+```
+
+You should be able to see on your terminal the output of calling the withdraw method.
+
+🎉 Congratulations! Have created your first contract and written a test to call it and test it locally! It's time to deploy your contract.
+
+## Deploy your contract
+
+Now things are getting serious, we will deploy our contract on our `devnet` :rocket:
+
+The `deploy` command will execute all deployment scripts it finds inside the `scripts` folder. Create the `scripts` folder in the root folder of the project:
+
+```sh
+mkdir scripts
+```
+
+Let's create a deployment script file called `0_deploy_faucet.ts` into the `scripts` folder and paste the following code.  
+Note that deployment scripts should always be prefixed with numbers (starting from `0`).
+
+```typescript
+import { Deployer, DeployFunction, Network } from '@alephium/cli'
+import { Settings } from '../alephium.config'
+import { TokenFaucet } from '../artifacts/ts'
+
+// This deploy function will be called by cli deployment tool automatically
+// Note that deployment scripts should prefixed with numbers (starting from 0)
+const deployFaucet: DeployFunction<Settings> = async (
+  deployer: Deployer
+): Promise<void> => {
+  const issueTokenAmount = 100n
+  const result = await deployer.deployContract(TokenFaucet, {
+    // The amount of token to be issued
+    issueTokenAmount: issueTokenAmount,
+    // The initial states of the faucet contract
+    initialFields: {
+      symbol: Buffer.from('TF', 'utf8').toString('hex'),
+      name: Buffer.from('TokenFaucet', 'utf8').toString('hex'),
+      decimals: 18n,
+      supply: issueTokenAmount,
+      balance: issueTokenAmount
+    }
+  })
+  console.log('Token faucet contract id: ' + result.contractId)
+  console.log('Token faucet contract address: ' + result.contractAddress)
+}
+
+export default deployFaucet
+```
+
+The [deployContract](https://github.com/alephium/alephium-web3/blob/d2b5b63cae015e843aa77b4cf484bc62a070f1d5/packages/cli/src/types.ts#L133-L137) of the `Deployer` takes our contract and deploys it with the correct arguments. You can also add a `taskTag` argument to tag your deployment with a specific name. By default, it will use the contract name, but if you deploy the same contract multiple times with different initial fields, your `.deployment` file will get overridden. Using a specific `taskTag` solves this issue.
+
+From the [DeployContractParams](https://github.com/alephium/alephium-web3/blob/d2b5b63cae015e843aa77b4cf484bc62a070f1d5/packages/web3/src/contract/contract.ts#L1286-L1293) interface, we can see that `initialFields` is mandatory as it contains the arguments for our `TokenFaucet` contract.
+
+With `issueTokenAmount` you can define how many tokens you want to issue, this is required if you want to create a token, otherwise no token-id will be created.
+
+Now, let's deploy!
+
+```sh
+npx @alephium/cli@latest deploy
+```
+
+...OOPS... It doesn't work???
+
+If you got the error `The node chain id x is different from configured chain id y`, go check your `networkId` in the devnet configuration and the `alephium.config.ts` file.
+
+`No UTXO found` ???
+
+Of course we didn't provide the `how-to-use-my-utxos`, we need to define our [privateKeys](https://github.com/alephium/alephium-web3/blob/d2b5b63cae015e843aa77b4cf484bc62a070f1d5/packages/cli/src/types.ts#L39-L46).
+
+You'll need to export the private keys from our wallet extension (might do it from our other wallets later), make sure to use a wallet with funds, like the one from the genesis allocation of your devnet. 
+If you used the docker way to launch your devnet, it might have work as we are defining [a default private key in our cli package](https://github.com/alephium/alephium-web3/blob/d2b5b63cae015e843aa77b4cf484bc62a070f1d5/packages/cli/src/types.ts#L75) based on the genesis allocation.
+
+Let's update our `alephium.config.ts`
+
+```typescript
+const configuration: Configuration<void> = {
+  defaultNetwork: 'devnet',
+  networks: {
+    devnet: {
+      nodeUrl: 'http://localhost:22973',
+      networkId: 2,
+      //The private key of my genesis address 132mqFF2BuxGigdaMTGSruuW29kmEs2eEGcpquG4YZRNh
+      privateKeys: ['672c8292041176c9056bb0dd1d91d34711ceed2493b5afc83f2012b27df2c559']
+    }
+  }
+}
+```
+
+and retry to deploy:
+
+```sh
+npx @alephium/cli@latest deploy
+```
+
+```sh
+Contracts are compiled already. Loading them from folder "artifacts"
+Deploying contract TokenFaucet
+Deployer - group 1 - 132mqFF2BuxGigdaMTGSruuW29kmEs2eEGcpquG4YZRNh
+Token faucet contract id: d00e9c788ddd572b0c186f0599a264f4c79f009c632c8040b7c5f71bfc0ec301
+Token faucet contract address: 28h7qSmkAAeNyoBuQKGyp1WG8VfdKPePCCFGKwp2Y8yyA
+✅ Deployment scripts executed!
+```
+
+Congratulations! Your contract is deployed. We can check the balance of the contract. Use `curl` and change the contract address based on your deployment result:
+
+```sh
+curl 'http://localhost:22973/addresses/28h7qSmkAAeNyoBuQKGyp1WG8VfdKPePCCFGKwp2Y8yyA/balance'
+```
+
+The response should look like this:
+
+```json
+{
+  "balance": "1000000000000000000",
+  "balanceHint": "1 ALPH",
+  "lockedBalance": "0",
+  "lockedBalanceHint": "0 ALPH",
+  "tokenBalances": [
+    {
+      "id": "d00e9c788ddd572b0c186f0599a264f4c79f009c632c8040b7c5f71bfc0ec301",
+      "amount": "100"
+    }
+  ],
+  "utxoNum": 1
+}
+```
+
+We can see our token id, with the 100 tokens we decided to issue.
+
+Let's check the contract state by first getting the group of our address: 
+
+```sh
+curl 'http://localhost:22973/addresses/28h7qSmkAAeNyoBuQKGyp1WG8VfdKPePCCFGKwp2Y8yyA/group'
+curl 'http://localhost:22973/contracts/28h7qSmkAAeNyoBuQKGyp1WG8VfdKPePCCFGKwp2Y8yyA/state?group=1'
+```
+
+
+Contract state response:
+```json
+{
+  "address": "28h7qSmkAAeNyoBuQKGyp1WG8VfdKPePCCFGKwp2Y8yyA",
+  "bytecode": "050609121b4024402d404a010000000102ce0002010000000102ce0102010000000102ce0202010000000102ce0302010000000102a0000201020101001116000e320c7bb4b11600aba00016002ba10005b416005f",
+  "codeHash": "641343b4f1c08b03969b127b452acc7535cad20231bc32af6c0b5f218dd8ff0c",
+  "initialStateHash": "06595afa695949e915dfc1220dfb47125b01751d9e193f4c5fa1c7fc3566673d",
+  "immFields": [
+    {
+      "type": "ByteVec",
+      "value": "5446"
+    },
+    {
+      "type": "ByteVec",
+      "value": "546f6b656e466175636574"
+    },
+    {
+      "type": "U256",
+      "value": "18"
+    },
+    {
+      "type": "U256",
+      "value": "100"
+    }
+  ],
+  "mutFields": [
+    {
+      "type": "U256",
+      "value": "100"
+    }
+  ],
+  "asset": {
+    "attoAlphAmount": "1000000000000000000",
+    "tokens": [
+      {
+        "id": "d00e9c788ddd572b0c186f0599a264f4c79f009c632c8040b7c5f71bfc0ec301",
+        "amount": "100"
+      }
+    ]
+  }
+}
+```
+
+In the `immFields` we can see our initial `TokenFaucet` arguments (`symbol`, `name`, `decimals`, `supply`). We can also see that `mutFields` contains the current token balance. We'll check that field later after calling the faucet.
+
+The `deploy` command also created a `.deployments.devnet.json` file, with the deployment result. It's important to keep that file to easily interact with the contract, even though all information can be found on the blockchain.
+
+# Interact with the deployed contract
+
+Having a token faucet is nice, getting tokens from it is even better.
+
+We can now write some code to interact with the faucet contract.
+
+We'll need to install our `cli` package and the `typescript` dependency if it's not yet the case:
+
+```
+npm install @alephium/cli typescript
+```
+
+We will now see a different option to interact with the blockchain. Previously we were using the `DeployFunction` with our `scripts/<number>_*` files which are automatically deployed with the CLI tool.
+
+Another way is to create a skeleton web application project using TypeScript. Create a `src` folder in the root folder of the project and a file called `tokens.ts` in it with the following contents.
+
+```typescript
+import { Deployments } from '@alephium/cli'
+import { web3, Project, NodeProvider } from '@alephium/web3'
+import { PrivateKeyWallet} from '@alephium/web3-wallet'
+import configuration from '../alephium.config'
+import { TokenFaucet, Withdraw } from '../artifacts/ts'
+
+async function withdraw() {
+
+  //Select our network defined in alephium.config.ts
+  const network = configuration.networks[configuration.defaultNetwork]
+
+  //NodeProvider is an abstraction of a connection to the Alephium network
+  const nodeProvider = new NodeProvider(network.nodeUrl)
+
+  //Sometimes, it's convenient to setup a global NodeProvider for your project:
+  web3.setCurrentNodeProvider(nodeProvider)
+
+  //Connect our wallet, typically in a real application you would connect your web-extension or desktop wallet
+  const wallet = new PrivateKeyWallet({privateKey: '672c8292041176c9056bb0dd1d91d34711ceed2493b5afc83f2012b27df2c559' })
+
+  // Compile the contracts of the project if they are not compiled
+  Project.build()
+
+  //.deployments contains the info of our `TokenFaucet` deployement, as we need to now the contractId and address
+  //This was auto-generated with the `cli deploy` of our `scripts/0_deploy_faucet.ts`
+  const deployments = await Deployments.from('.deployments.devnet.json')
+
+  //Make sure it match your address group
+  const accountGroup = 1
+
+  const deployed = deployments.getDeployedContractResult(accountGroup, 'TokenFaucet')
+
+  if(deployed !== undefined) {
+    const tokenId = deployed.contractId
+    const tokenAddress = deployed.contractAddress
+
+    // Submit a transaction to use the transaction script
+    // It uses our `wallet` to sing the transaction.
+    await Withdraw.execute(wallet, {
+      initialFields: { token: tokenId, amount: 1n }
+    })
+
+    // Fetch the latest state of the token contract, `mut balance` should have change
+    const faucet = TokenFaucet.at(tokenAddress)
+    const state = await faucet.fetchState()
+    console.log(state.fields)
+
+    // Fetch wallet balance see if token is there
+    const balance = await wallet.nodeProvider.addresses.getAddressesAddressBalance(wallet.account.address)
+    console.log(balance)
+  } else {
+    console.log('`deployed` is undefined')
+  }
+}
+
+// Let's perform one withdraw
+withdraw()
+```
+
+For the attentive people, you'll see something new coming from our `artifacts`: [`Withdraw`](https://github.com/alephium/nextjs-template/blob/main/contracts/withdraw.ral) which is a [`TxScript`](https://wiki.alephium.org/ralph/getting-started#txscript) required to interact with the `TokenFaucet` contract. Its code is quite simple. Create a file called `withdraw.ral` in the `contracts` folder and paste the following code:
+
+```rust
+TxScript Withdraw(token: TokenFaucet, amount: U256) {
+    token.withdraw(amount)
+}
+```
+
+We now need to recompile our contracts to get the artifact for `Withdraw`:
+
+```sh
+npx @alephium/cli@latest compile
+```
+
+You can now compile the TypeScript code to JavaScript with:
+
+```sh
+npx tsc --build .
+```
+
+OOPS, you should get an error coming from the `alephium.config.ts`, until now the config was used as a simple JSON, but now `TypeScript` want it to respect its [interface](https://github.com/alephium/alephium-web3/blob/d2b5b63cae015e843aa77b4cf484bc62a070f1d5/packages/cli/src/types.ts#L48-L62). Especially the `networks` is a record that need to contain the 3 `NetworkType`. You can try to fix it by yourself or update your `alephium.config.ts` file with:
+
+```typescript
+import { Configuration } from '@alephium/cli'
+
+export type Settings = {}
+
+const configuration: Configuration<Settings> = {
+  defaultNetwork: 'devnet',
+  networks: {
+    devnet: {
+      nodeUrl: 'http://localhost:22973',
+      networkId: 2, //Use the same as in your devnet configuration
+      privateKeys: ['672c8292041176c9056bb0dd1d91d34711ceed2493b5afc83f2012b27df2c559'],
+      settings: {}
+    },
+    testnet: {
+      nodeUrl: '',
+      privateKeys: [],
+      settings: {}
+    },
+    mainnet: {
+      nodeUrl: '',
+      privateKeys: [],
+      settings: {}
+    }
+  }
+}
+
+export default configuration
+```
+
+Now recompile
+
+```
+npx tsc --build .
+```
+
+A `dist` folder should have been created, go ahead and interact with the deployed token faucet:
+
+```
+node dist/src/token.js
+```
+
+You should now be a proud owner of the token you created.
+
+
+## What's next?
+
+You can find a more complex example of the token faucet tutorial [in the alephium/nextjs-template](https://github.com/alephium/nextjs-template) project.
+
+## Connect to the wallets
+
+dApp requires wallet integration for users of the dApp to authenticate and interact with the Alephium blockchain,
+such as transactions signing. Currently dApps can be integrated with both [Extension Wallet](../wallet/extension-wallet/dapp)
+and [WalletConnect](../wallet/walletconnect). Please refer to the respective pages for more details.
+
+## Learn more
+
+- To learn more about the ecosystem, please visit the [overview of ecosystem](/dapps/ecosystem).
+- To learn more about the web3 SDK, please visit the [guide of web3 SDK](/dapps/alephium-web3).
+- To learn more about Ralph language, please visit the [guide of Ralph](/ralph/getting-started).
+- To learn how to build a Nextjs dApp, please visit [Build dApp with Nextjs](/dapps/build-dapp-with-nextjs.md)

--- a/docs/dapps/build-dapp-from-scratch.md
+++ b/docs/dapps/build-dapp-from-scratch.md
@@ -23,6 +23,8 @@ Prerequisites:
 
 In this tutorial we will write our first dApp: A token faucet.
 
+The code here is taken from our [getting started page](/dapps/getting-started), but we will see step by step how we build this guide.
+
 Create a new project folder and navigate into it:
 
 ```sh

--- a/docs/dapps/build-dapp-from-scratch.md
+++ b/docs/dapps/build-dapp-from-scratch.md
@@ -38,7 +38,7 @@ Let's now create a `contracts` folder where we'll store all our contracts:
 mkdir contracts
 ```
 
-Our first contract we'll be `token.ral` which can be found [here](https://github.com/alephium/nextjs-template/blob/main/contracts/token.ral). You can copy the whole file into your `contracts` folder.
+Our first contract will be `token.ral` which can be found [here](https://github.com/alephium/nextjs-template/blob/main/contracts/token.ral). You can copy the whole file into your `contracts` folder.
 
 Let's inspect it, piece by piece:
 
@@ -155,8 +155,8 @@ describe('unit tests', () => {
     web3.setCurrentNodeProvider('http://127.0.0.1:22973')
     await Project.build()
 
-    let testContractId = randomContractId()
-    let testParams = {
+    const testContractId = randomContractId()
+    const testParams = {
       // a random address that the test contract resides in the tests
       address: addressFromContractId(testContractId),
       // assets owned by the test contract before a test

--- a/docs/dapps/getting-started.md
+++ b/docs/dapps/getting-started.md
@@ -10,7 +10,7 @@ import UntranslatedPageText from "@site/src/components/UntranslatedPageText";
 
 ## Overview
 
-Alephium proposes multiple tools and package to help you build your dApps.
+Alephium proposes multiple tools and packages to help you build your dApps.
 
 This guide will help you install our recommended setup.
 
@@ -39,7 +39,7 @@ To compile and test your contracts, it's necessary to launch a local development
 npx @alephium/cli@latest devnet start
 ```
 
-Your new network is now launched using [this configuration](https://github.com/alephium/alephium-web3/blob/master/packages/cli/devnet-user.conf)
+Your new network is now launched using [this configuration](https://github.com/alephium/alephium-web3/blob/master/packages/cli/devnet-user.conf) and generated addresses in 4 groups with enough ALPHs for testing purposes.
 
 The Typescript SDK is then able to interact with the network through REST endpoints.
 

--- a/docs/dapps/getting-started.md
+++ b/docs/dapps/getting-started.md
@@ -8,6 +8,8 @@ import UntranslatedPageText from "@site/src/components/UntranslatedPageText";
 
 <UntranslatedPageText />
 
+#Dapps Getting started
+
 This guide will explore the basics of creating an Alephium dApp project.
 
 Prerequisites:
@@ -15,83 +17,521 @@ Prerequisites:
 - Write code in [Typescript](https://www.typescriptlang.org/)
 - Operate in a [terminal](https://en.wikipedia.org/wiki/Terminal_emulator)
 
-## Create a new dApp project
+## Create a new dApp project: Token Faucet
 
-To create the tutorial project, open a new terminal and run:
+In this tutorial we will write our first dApp: A token faucet.
 
-```
-npx @alephium/cli@latest init alephium-tutorial
-```
+Create a directory for tuto.
 
-This will create a new directory `alephium-tutorial` and initialize a sample project inside that directory.
-
-## Launch the local development network
-
-To compile and test your contracts, it's necessary to launch a local development network by running:
-
-```
-npx @alephium/cli@latest devnet start
+```sh
+mkdir alephium-faucet-tuto
+cd alephium-faucet-tuto
 ```
 
-The Typescript SDK is then able to interact with the network through REST endpoints.
+Let's now create a `contracts` folder where we'll store all our contracts
 
-Alternatively, if you want to create a local development network with explorer support, please use `docker-compose` and follow the instructions in [alphium-stack](https://github.com/alephium/alephium-stack#devnet).
+```sh
+mkdir contracts
+```
+
+Our first contract we'll be `token.ral` which can be found [here](https://github.com/alephium/nextjs-template/blob/main/contracts/token.ral), you can copy it into your `contracts` folder.
+Let's dive into it.
+
+```
+import "std/token_interface"
+
+Contract TokenFaucet(
+    symbol: ByteVec,
+    name: ByteVec,
+    decimals: U256,
+    supply: U256,
+    mut balance: U256
+) implements IToken {
+```
+
+The first four fields will be immutable values that store the data required to served our [IToken interface](https://github.com/alephium/alephium-web3/blob/master/packages/web3/std/token_interface.ral).
+`mut balance` is a mutable value that keep track on how many tokens are left in this faucet.
+
+You can see that our contract is emitting some `event` and define an `error` code. Read the following for more info on the [events](https://wiki.alephium.org/ralph/getting-started#events) and the [error handling](https://wiki.alephium.org/ralph/getting-started#error-handling).
+
+This is followed by five access method for the different contract's arguments.
+
+The latest function is where the magic happen:
+
+```rust
+@using(assetsInContract = true, updateFields = true)
+pub fn withdraw(amount: U256) -> () {
+    // Debug events can be helpful for error analysis
+    emit Debug(`The current balance is ${balance}`)
+
+    // Make sure the amount is valid
+    assert!(amount <= 2, ErrorCodes.InvalidWithdrawAmount)
+    // Functions postfixed with `!` are built-in functions.
+    transferTokenFromSelf!(callerAddress!(), selfTokenId!(), amount)
+    // Ralph does not allow underflow.
+    balance = balance - amount
+
+    // Emit the event defined earlier.
+    emit Withdraw(callerAddress!(), amount)
+}
+```
+
+With the `assert!` We make sure no one take more than 2 tokens at the same time.
+`transferTokenFromSelf` will actually perform the transfer of token.
+We update the `mut balance` field with the new balance, if it goes underflow and error will be raised and the transaction won't be perform.
 
 ## Compile your contract
 
-Next, change the workspace to the tutorial project:
+The compiler needs to contact the full node in order to compile, we define the node url using with the following config file: `alephium.config.ts`
 
-```
-cd alephium-tutorial
+```typescript
+import { Configuration } from '@alephium/cli'
+
+const configuration: Configuration<void> = {
+  defaultNetwork: 'devnet',
+  networks: {
+    devnet: {
+      //Make sure the two values match what's in your `~/.alephium/user.conf
+      nodeUrl: 'http://localhost:22973',
+      networkId: 2
+    }
+  }
+}
+
+export default configuration
 ```
 
-and compile your contracts:
+Make sure to use the correct host and port.
 
-```
+Now let's compile:
+
+```sh
 npx @alephium/cli@latest compile
 ```
 
-If you take a look at `contracts/`, you should be able to find `token.ral`. The compiled artifacts are in the directory `artifacts`.
+It may ask you some confirmation to install the latest `@alephium/cli` package.
 
-This command also generates typescript code based on the compiled artifacts. The generated typescript code are in the directory `artifacts/ts`. You can interact with the alephium blockchain more conveniently by using the generated typescript code.
+You can check the produced result into `artifacts`. For example `artifacts/ts/TokenFaucet.ts` produce lots of helper functions: `at, fetchState, call*, etc`, as well as test functions.
 
 ## Test your contract
+The SDK provides unit test functionalities, which calls the contract like a normal transaction, but instead of changing the blockchain state, it returns the new contract state, transaction outputs, and events.
 
-The sample project comes with tests `test/token.test.ts` for your contract. You can run your tests with:
+Install the test framework:
 
+```sh
+npm install ts-jest @types/jest
 ```
-npm run test
+
+You'll also need our `web3` package
+
+```sh
+npm install @alephium/web3 @alephium/web3-test
 ```
 
-or
+Create a `test` folder:
 
+```sh
+mkdir test
 ```
+
+and add this minimal test: `test/token.test.ts`
+
+```typescript
+import { web3, Project, addressFromContractId } from '@alephium/web3'
+import { randomContractId, testAddress } from '@alephium/web3-test'
+import { TokenFaucet } from '../artifacts/ts'
+
+describe('unit tests', () => {
+  it('test withdraw', async () => {
+
+    // Use the correct host and port
+    web3.setCurrentNodeProvider('http://127.0.0.1:22973')
+    await Project.build()
+
+    let testContractId = randomContractId()
+    let testParams = {
+      // a random address that the test contract resides in the tests
+      address: addressFromContractId(testContractId),
+      // assets owned by the test contract before a test
+      initialAsset: { alphAmount: 10n ** 18n, tokens: [{ id: testContractId, amount: 10n }] },
+      // initial state of the test contract
+      initialFields: {
+        symbol: Buffer.from('TF', 'utf8').toString('hex'),
+        name: Buffer.from('TokenFaucet', 'utf8').toString('hex'),
+        decimals: 18n,
+        supply: 10n ** 18n,
+        balance: 10n
+      },
+      // arguments to test the target function of the test contract
+      testArgs: { amount: 1n },
+      // assets owned by the caller of the function
+      inputAssets: [{ address: testAddress, asset: { alphAmount: 10n ** 18n } }]
+    }
+
+    const testResult = await TokenFaucet.testWithdrawMethod(testParams)
+    console.log(testResult)
+  })
+})
+```
+
+A more complex test can be found [here](https://github.com/alephium/nextjs-template/blob/main/test/token.test.ts)
+
+Without entering to much into details, `Typescript` needs some configuration to run the test, just copy the following into `tsconfig.json`
+
+```json
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "target": "es2020",
+    "esModuleInterop": true,
+    "module": "commonjs",
+    "resolveJsonModule": true
+  },
+  "exclude": ["node_modules"],
+  "include": ["src/**/*.ts", "test/**/*.ts", "scripts/**/*.ts", "alephium.config.ts", "artifacts/**/*.ts"]
+}
+```
+
+You can now run the test:
+
+```sh
 npx @alephium/cli@latest test
 ```
 
+Congratulations, you should see what result would produce a withdraw.
+
 ## Deploy your contract
 
-Next, to deploy the contract we will use Alephium CLI and a deployment script `scripts/0_deploy_faucet.ts`. You can run it using:
+Now things are getting serious, we will deploy our contract on our `devnet` :rocket:
 
+The `deploy` command will deploy everything which is inside the `scripts` folder.
+
+```sh
+mkdir scripts
 ```
+
+Let's create this file into this folder: `scripts/0_deploy_faucet.ts`
+Note that deployment scripts should prefixed with numbers (starting from 0)
+
+```typescript
+import { Deployer, DeployFunction, Network } from '@alephium/cli'
+import { Settings } from '../alephium.config'
+import { TokenFaucet } from '../artifacts/ts'
+
+// This deploy function will be called by cli deployment tool automatically
+// Note that deployment scripts should prefixed with numbers (starting from 0)
+const deployFaucet: DeployFunction<Settings> = async (
+  deployer: Deployer
+): Promise<void> => {
+  const issueTokenAmount = 100n
+  const result = await deployer.deployContract(TokenFaucet, {
+    // The amount of token to be issued
+    issueTokenAmount: issueTokenAmount,
+    // The initial states of the faucet contract
+    initialFields: {
+      symbol: Buffer.from('TF', 'utf8').toString('hex'),
+      name: Buffer.from('TokenFaucet', 'utf8').toString('hex'),
+      decimals: 18n,
+      supply: issueTokenAmount,
+      balance: issueTokenAmount
+    }
+  })
+  console.log('Token faucet contract id: ' + result.contractId)
+  console.log('Token faucet contract address: ' + result.contractAddress)
+}
+
+export default deployFaucet
+```
+
+[deployContract](https://github.com/alephium/alephium-web3/blob/d2b5b63cae015e843aa77b4cf484bc62a070f1d5/packages/cli/src/types.ts#L133-L137) takes our contract and deploy it with the correct arguments, you can also add a `taskTag` arguments, to tag your deployment with a specific name. By default it will use the contract name, but if you deploy multiple time the same contract with different initial fields, your `.deployement` file will get override, using a specific `taskTag` solve this issue.
+
+From the [DeployContractParams](https://github.com/alephium/alephium-web3/blob/d2b5b63cae015e843aa77b4cf484bc62a070f1d5/packages/web3/src/contract/contract.ts#L1286-L1293) interface, we can see that `initialFields` is mandatory as it contains the arguments for our `TokenFaucet` contract.
+
+With `issueTokenAmount` you can define how many tokens you want to issue, this is required if you want to create a token, otherwise no token-id will be created.
+
+Now let's deploy!!!
+
+```sh
 npx @alephium/cli@latest deploy
 ```
 
-This will deploy the token faucet to all of the 4 groups of Devnet. You could configure `alephium.config.ts` to deploy the contract to different networks.
+...OOPS... It doesn't work???
 
-## Interact with the deployed contract
+`NO UTXO found` ???
 
-Now, you can build the source code `src/token.ts` with:
+Of course we didn't provide the `how-to-use-my-utxos`, we need to define our [privateKeys](https://github.com/alephium/alephium-web3/blob/d2b5b63cae015e843aa77b4cf484bc62a070f1d5/packages/cli/src/types.ts#L39-L46).
+
+
+You'll need to export the private keys from our wallet extension (might do it from our other wallets latter), make sure to use a wallet with funds, like the one from the genesis allocation of your devnet.
+
+Let's update our `alephium.config.ts`
+
+```typescript
+const configuration: Configuration<void> = {
+  defaultNetwork: 'devnet',
+  networks: {
+    devnet: {
+      nodeUrl: 'http://localhost:22973',
+      networkId: 2,
+      //The private key of my genesis address 132mqFF2BuxGigdaMTGSruuW29kmEs2eEGcpquG4YZRNh
+      privateKeys: ['672c8292041176c9056bb0dd1d91d34711ceed2493b5afc83f2012b27df2c559']
+    }
+  }
+}
+```
+
+and retry to deploy:
+
+```sh
+npx @alephium/cli@latest deploy
+```
+
+```sh
+Contracts are compiled already. Loading them from folder "artifacts"
+Deploying contract TokenFaucet
+Deployer - group 1 - 132mqFF2BuxGigdaMTGSruuW29kmEs2eEGcpquG4YZRNh
+Token faucet contract id: d00e9c788ddd572b0c186f0599a264f4c79f009c632c8040b7c5f71bfc0ec301
+Token faucet contract address: 28h7qSmkAAeNyoBuQKGyp1WG8VfdKPePCCFGKwp2Y8yyA
+✅ Deployment scripts executed!
+```
+
+Congratulations! Your contract is deployed. We can check the balance of the contract:
+Change the contract address base on your deployment result
+
+```sh
+curl 'http://localhost:22973/addresses/28h7qSmkAAeNyoBuQKGyp1WG8VfdKPePCCFGKwp2Y8yyA/balance'
+```
+
+Response:
+
+```json
+{
+  "balance": "1000000000000000000",
+  "balanceHint": "1 ALPH",
+  "lockedBalance": "0",
+  "lockedBalanceHint": "0 ALPH",
+  "tokenBalances": [
+    {
+      "id": "d00e9c788ddd572b0c186f0599a264f4c79f009c632c8040b7c5f71bfc0ec301",
+      "amount": "100"
+    }
+  ],
+  "utxoNum": 1
+}
+```
+
+We can see our token id, with the 100 token we decided to issue.
+
+Let's check the contract state:
+
+```sh
+curl 'http://localhost:22973/contracts/28h7qSmkAAeNyoBuQKGyp1WG8VfdKPePCCFGKwp2Y8yyA/state?group=1'
+```
+
+The `group` value may vary depending of your deploying address. You can always get your group number with the `curl 'http://localhost:22973/addresses/<your-address>/group'`  endpoint.
+
+Contract state response:
+```json
+{
+  "address": "28h7qSmkAAeNyoBuQKGyp1WG8VfdKPePCCFGKwp2Y8yyA",
+  "bytecode": "050609121b4024402d404a010000000102ce0002010000000102ce0102010000000102ce0202010000000102ce0302010000000102a0000201020101001116000e320c7bb4b11600aba00016002ba10005b416005f",
+  "codeHash": "641343b4f1c08b03969b127b452acc7535cad20231bc32af6c0b5f218dd8ff0c",
+  "initialStateHash": "06595afa695949e915dfc1220dfb47125b01751d9e193f4c5fa1c7fc3566673d",
+  "immFields": [
+    {
+      "type": "ByteVec",
+      "value": "5446"
+    },
+    {
+      "type": "ByteVec",
+      "value": "546f6b656e466175636574"
+    },
+    {
+      "type": "U256",
+      "value": "18"
+    },
+    {
+      "type": "U256",
+      "value": "100"
+    }
+  ],
+  "mutFields": [
+    {
+      "type": "U256",
+      "value": "100"
+    }
+  ],
+  "asset": {
+    "attoAlphAmount": "1000000000000000000",
+    "tokens": [
+      {
+        "id": "d00e9c788ddd572b0c186f0599a264f4c79f009c632c8040b7c5f71bfc0ec301",
+        "amount": "100"
+      }
+    ]
+  }
+}
+```
+
+In the `immFields` we can find back our `TokenFaucet` initial arguments, `symbol/name/decimals/supply` and the `mutFields` contains the current token balance, we'll check latter that field after calling the faucet.
+
+The `deploy` command also create a `.deployments.devnet.json` file, with the deployment result. It's important to keep that file to easily interact latter with the contract, even tho all informations can be found back on the blockchain.
+
+# Interact with the deployed contract
+
+Having a token faucet is nice, getting tokens from it is even better.
+
+We can now write some code to interact with the faucet contract.
+
+We'll need to install our `cli` package and the `typescript` dependency if it's not yet the case:
 
 ```
-npm run build
+npm install @alephium/cli typescript
 ```
 
-and interact with the deployed token faucet:
+We will now see another way to interact with the blockchain, previously we were using the `DeployFunction` with our `scripts/x_*` files. Which are automatically deploy with the cli tool.
+
+The next way is a skeleton of what you could do for a web-application.
+This will be a `TypeScript` application and code goes into the `src` folder.
+
+```sh
+mkdir src
+```
+
+Let's create the following file, `src/token.ts`:
+
+```typescript
+import { Deployments } from '@alephium/cli'
+import { web3, Project, NodeProvider } from '@alephium/web3'
+import { PrivateKeyWallet} from '@alephium/web3-wallet'
+import configuration from '../alephium.config'
+import { TokenFaucet, Withdraw } from '../artifacts/ts'
+
+async function withdraw() {
+
+  //Select our network defined in alephium.config.ts
+  const network = configuration.networks[configuration.defaultNetwork]
+
+  //NodeProvider is an abstraction of a connection to the Alephium network
+  const nodeProvider = new NodeProvider(network.nodeUrl)
+
+  //Sometimes, it's convenient to setup a global NodeProvider for your project:
+  web3.setCurrentNodeProvider(nodeProvider)
+
+  //Connect our wallet, typically in a real application you would connect your web-extension or desktop wallet
+  const wallet = new PrivateKeyWallet({privateKey: '672c8292041176c9056bb0dd1d91d34711ceed2493b5afc83f2012b27df2c559' })
+
+  // Compile the contracts of the project if they are not compiled
+  Project.build()
+
+  //.deployments contains the info of our `TokenFaucet` deployement, as we need to now the contractId and address
+  //This was auto-generated with the `cli deploy` of our `scripts/0_deploy_faucet.ts`
+  const deployments = await Deployments.from('.deployments.devnet.json')
+
+  //Make sure it match your address group
+  const accountGroup = 1
+
+  const deployed = deployments.getDeployedContractResult(accountGroup, 'TokenFaucet')
+
+  if(deployed !== undefined) {
+    const tokenId = deployed.contractId
+    const tokenAddress = deployed.contractAddress
+
+    // Submit a transaction to use the transaction script
+    // It uses our `wallet` to sing the transaction.
+    await Withdraw.execute(wallet, {
+      initialFields: { token: tokenId, amount: 1n }
+    })
+
+    // Fetch the latest state of the token contract, `mut balance` should have change
+    const faucet = TokenFaucet.at(tokenAddress)
+    const state = await faucet.fetchState()
+    console.log(state.fields)
+
+    // Fetch wallet balance see if token is there
+    const balance = await wallet.nodeProvider.addresses.getAddressesAddressBalance(wallet.account.address)
+    console.log(balance)
+  } else {
+    console.log('`deployed` is undefined')
+  }
+}
+
+// Let's perform one withdraw
+withdraw()
+```
+
+For the attentive people, you'll see something new coming from our `artifacts`: [Withdraw](https://github.com/alephium/nextjs-template/blob/main/contracts/withdraw.ral) which is a [TxScript](https://wiki.alephium.org/ralph/getting-started#txscript) required to interact with the `TokenFaucet` contract. Its code is quite simple, you can add this to you `contracts/withdraw.ral`
+
+```rust
+TxScript Withdraw(token: TokenFaucet, amount: U256) {
+    token.withdraw(amount)
+}
+```
+
+We now need to recompile our contracts to get the artifact for `Withdraw`
+
+```sh
+npx @alephium/cli@latest compile
+```
+
+The code of `token.ts` should be self-explanatory, you can read more on our [web3-sdk here](https://wiki.alephium.org/dapps/alephium-web3)
+
+You can now try to compile.
+
+```sh
+npx tsc --build .
+```
+
+OOPS, you should get an error coming from the `alephium.config.ts`, until now the config was used as a simple JSON, but now `TypeScript` want it to respect its [interface](https://github.com/alephium/alephium-web3/blob/d2b5b63cae015e843aa77b4cf484bc62a070f1d5/packages/cli/src/types.ts#L48-L62). Especially the `networks` is a record that need to contain the 3 `NetworkType`. You can try to fix it by yourself or update your `alephium.config.ts` file with:
+
+```typescript
+import { Configuration } from '@alephium/cli'
+
+export type Settings = {}
+
+const configuration: Configuration<Settings> = {
+  defaultNetwork: 'devnet',
+  networks: {
+    devnet: {
+      nodeUrl: 'http://localhost:22973',
+      networkId: 2, //Use the same as in your `~/.alephium/user.conf
+      privateKeys: ['672c8292041176c9056bb0dd1d91d34711ceed2493b5afc83f2012b27df2c559'],
+      settings: {}
+    },
+    testnet: {
+      nodeUrl: '',
+      privateKeys: [],
+      settings: {}
+    },
+    mainnet: {
+      nodeUrl: '',
+      privateKeys: [],
+      settings: {}
+    }
+  }
+}
+
+export default configuration
+```
+
+Now recompile
+
+```
+npx tsc --build .
+```
+
+A `dist` folder should have been created, go ahead and interact with the deployed token faucet:
 
 ```
 node dist/src/token.js
 ```
+
+You should now be a proud owner of the token you created.
+
+
+## What's next?
+
+You can find a more complex example of the token faucet tutorial [here](https://github.com/alephium/nextjs-template)
 
 ## Connect to the wallets
 

--- a/docs/dapps/getting-started.md
+++ b/docs/dapps/getting-started.md
@@ -16,6 +16,8 @@ Prerequisites:
 
 - Write code in [Typescript](https://www.typescriptlang.org/)
 - Operate in a [terminal](https://en.wikipedia.org/wiki/Terminal_emulator)
+- [nodejs](https://nodejs.org/en/) version >= 16 installed
+- `npm` version >= 8 installed
 
 ## Create a new dApp project: Token Faucet
 
@@ -83,16 +85,20 @@ We update the `mut balance` field with the new balance. In the case of underflow
 `callerAddress!()` and `selfTokenId!()` are built-in functions, you can read more about them in our [built-in functions page](/ralph/built-in-functions).
 ## Compile your contract
 
-The compiler needs to contact the full node in order to compile the contract. We define the node URL using the following config file: `alephium.config.ts`. Create this file in the root directory of your project and paste the following code:
+The compiler needs to contact the full node in order to compile the contract, you'll need to use the right information defined while [creating your devnet](/full-node/devnet). If you haven't start it, now it's the time.
+We define the node URL using the following config file: `alephium.config.ts`. 
+Create this file in the root directory of your project and paste the following code:
 
 ```typescript
 import { Configuration } from '@alephium/cli'
 
-const configuration: Configuration<void> = {
+export type Settings = {}
+
+const configuration: Configuration<Settings> = {
   defaultNetwork: 'devnet',
   networks: {
     devnet: {
-      //Make sure the two values match what's in your `~/.alephium/user.conf
+      //Make sure the two values match what's in your devnet configuration
       nodeUrl: 'http://localhost:22973',
       networkId: 2
     }
@@ -101,8 +107,6 @@ const configuration: Configuration<void> = {
 
 export default configuration
 ```
-
-Make sure to use the correct host and port.
 
 Now, let's compile:
 
@@ -260,12 +264,14 @@ npx @alephium/cli@latest deploy
 
 ...OOPS... It doesn't work???
 
-`NO UTXO found` ???
+If you got the error `The node chain id x is different from configured chain id y`, go check your `networkId` in the devnet configuration and the `alephium.config.ts` file.
+
+`No UTXO found` ???
 
 Of course we didn't provide the `how-to-use-my-utxos`, we need to define our [privateKeys](https://github.com/alephium/alephium-web3/blob/d2b5b63cae015e843aa77b4cf484bc62a070f1d5/packages/cli/src/types.ts#L39-L46).
 
-
-You'll need to export the private keys from our wallet extension (might do it from our other wallets latter), make sure to use a wallet with funds, like the one from the genesis allocation of your devnet.
+You'll need to export the private keys from our wallet extension (might do it from our other wallets later), make sure to use a wallet with funds, like the one from the genesis allocation of your devnet. 
+If you used the docker way to launch your devnet, it might have work as we are defining [a default private key in our cli package](https://github.com/alephium/alephium-web3/blob/d2b5b63cae015e843aa77b4cf484bc62a070f1d5/packages/cli/src/types.ts#L75) based on the genesis allocation.
 
 Let's update our `alephium.config.ts`
 
@@ -391,16 +397,9 @@ We'll need to install our `cli` package and the `typescript` dependency if it's 
 npm install @alephium/cli typescript
 ```
 
-We will now see another way to interact with the blockchain. Previously we were using the `DeployFunction` with our `scripts/<number>_*` files which are automatically deployed with the CLI tool.
+We will now see a different option to interact with the blockchain. Previously we were using the `DeployFunction` with our `scripts/<number>_*` files which are automatically deployed with the CLI tool.
 
-The next way is a skeleton of what you could do for a web-application.
-This will be a `TypeScript` application and code goes into the `src` folder.
-
-```sh
-mkdir src
-```
-
-Let's create the following file, `src/token.ts`:
+Another way is to create a skeleton web application project using TypeScript. Create a `src` folder in the root folder of the project and a file called `tokens.ts` in it with the following contents.
 
 ```typescript
 import { Deployments } from '@alephium/cli'
@@ -476,8 +475,6 @@ We now need to recompile our contracts to get the artifact for `Withdraw`:
 npx @alephium/cli@latest compile
 ```
 
-The code of `token.ts` should be self-explanatory, you can read more on our [web3-sdk here](https://wiki.alephium.org/dapps/alephium-web3)
-
 You can now compile the TypeScript code to JavaScript with:
 
 ```sh
@@ -496,7 +493,7 @@ const configuration: Configuration<Settings> = {
   networks: {
     devnet: {
       nodeUrl: 'http://localhost:22973',
-      networkId: 2, //Use the same as in your `~/.alephium/user.conf
+      networkId: 2, //Use the same as in your devnet configuration
       privateKeys: ['672c8292041176c9056bb0dd1d91d34711ceed2493b5afc83f2012b27df2c559'],
       settings: {}
     },

--- a/docs/dapps/getting-started.md
+++ b/docs/dapps/getting-started.md
@@ -8,12 +8,18 @@ import UntranslatedPageText from "@site/src/components/UntranslatedPageText";
 
 <UntranslatedPageText />
 
-This guide will explore the basics of creating an Alephium dApp project.
+## Overview
+
+Alephium proposes multiple tools and package to help you build your dApps.
+
+This guide will help you install our recommended setup.
 
 Prerequisites:
 
 - Write code in [Typescript](https://www.typescriptlang.org/)
 - Operate in a [terminal](https://en.wikipedia.org/wiki/Terminal_emulator)
+- [nodejs](https://nodejs.org/en/) version >= 16 installed
+- `npm` version >= 8 installed
 
 ## Create a new dApp project
 
@@ -33,6 +39,8 @@ To compile and test your contracts, it's necessary to launch a local development
 npx @alephium/cli@latest devnet start
 ```
 
+Your new network is now launched using [this configuration](https://github.com/alephium/alephium-web3/blob/master/packages/cli/devnet-user.conf)
+
 The Typescript SDK is then able to interact with the network through REST endpoints.
 
 Alternatively, if you want to create a local development network with explorer support, please use `docker-compose` and follow the instructions in [alphium-stack](https://github.com/alephium/alephium-stack#devnet).
@@ -45,19 +53,149 @@ Next, change the workspace to the tutorial project:
 cd alephium-tutorial
 ```
 
-and compile your contracts:
+Have a look in the `contracts/` folder, you can find `token.ral`:
+
+```rust
+import "std/token_interface"
+
+// Defines a contract named `TokenFaucet`.
+// A contract is a collection of fields (its state) and functions.
+// Once deployed, a contract resides at a specific address on the Alephium blockchain.
+// Contract fields are permanently stored in contract storage.
+// A contract can issue an initial amount of token at its deployment.
+Contract TokenFaucet(
+    symbol: ByteVec,
+    name: ByteVec,
+    decimals: U256,
+    supply: U256,
+    mut balance: U256
+) implements IToken {
+
+    // Events allow for logging of activities on the blockchain.
+    // Alephium clients can listen to events in order to react to contract state changes.
+    event Withdraw(to: Address, amount: U256)
+
+    enum ErrorCodes {
+        InvalidWithdrawAmount = 0
+    }
+
+    // A public function that returns the initial supply of the contract's token.
+    // Note that the field must be initialized as the amount of the issued token.
+    pub fn getTotalSupply() -> U256 {
+        return supply
+    }
+
+    // A public function that returns the symbol of the token.
+    pub fn getSymbol() -> ByteVec {
+        return symbol
+    }
+
+    // A public function that returns the name of the token.
+    pub fn getName() -> ByteVec {
+        return name
+    }
+
+    // A public function that returns the decimals of the token.
+    pub fn getDecimals() -> U256 {
+        return decimals
+    }
+
+    // A public function that returns the current balance of the contract.
+    pub fn balance() -> U256 {
+        return balance
+    }
+
+    // A public function that transfers tokens to anyone who calls it.
+    // The function is annotated with `updateFields = true` as it changes the contract fields.
+    // The function is annotated as using contract assets as it does.
+    @using(assetsInContract = true, updateFields = true)
+    pub fn withdraw(amount: U256) -> () {
+        // Debug events can be helpful for error analysis
+        emit Debug(`The current balance is ${balance}`)
+
+        // Make sure the amount is valid
+        assert!(amount <= 2, ErrorCodes.InvalidWithdrawAmount)
+        // Functions postfixed with `!` are built-in functions.
+        transferTokenFromSelf!(callerAddress!(), selfTokenId!(), amount)
+        // Ralph does not allow underflow.
+        balance = balance - amount
+
+        // Emit the event defined earlier.
+        emit Withdraw(callerAddress!(), amount)
+    }
+}
+```
+
+and `withdraw.ral` :
+
+```rust
+// Defines a transaction script.
+// A transaction script is a piece of code to interact with contracts on the blockchain.
+// Transaction scripts can use the input assets of transactions in general.
+// A script is disposable and will only be executed once along with the holder transaction.
+TxScript Withdraw(token: TokenFaucet, amount: U256) {
+    // Call token contract's withdraw function.
+    token.withdraw(amount)
+}
+```
+
+ To compile your contracts, run:
 
 ```
 npx @alephium/cli@latest compile
 ```
 
-If you take a look at `contracts/`, you should be able to find `token.ral`. The compiled artifacts are in the directory `artifacts`.
+The compiled artifacts are in the directory `artifacts`.
 
 This command also generates typescript code based on the compiled artifacts. The generated typescript code are in the directory `artifacts/ts`. You can interact with the alephium blockchain more conveniently by using the generated typescript code.
 
 ## Test your contract
 
-The sample project comes with tests `test/token.test.ts` for your contract. You can run your tests with:
+The sample project comes with tests `test/token.test.ts` for your contract:
+
+```typescript
+import { web3, Project, TestContractParams, addressFromContractId, AssetOutput, DUST_AMOUNT } from '@alephium/web3'
+import { expectAssertionError, randomContractId, testAddress, testNodeWallet } from '@alephium/web3-test'
+import { deployToDevnet } from '@alephium/cli'
+import { TokenFaucet, TokenFaucetTypes, Withdraw } from '../artifacts/ts'
+
+describe('unit tests', () => {
+  let testContractId: string
+  let testTokenId: string
+  let testContractAddress: string
+  let testParamsFixture: TestContractParams<TokenFaucetTypes.Fields, { amount: bigint }>
+
+  // We initialize the fixture variables before all tests
+  beforeAll(async () => {
+    web3.setCurrentNodeProvider('http://127.0.0.1:22973')
+    await Project.build()
+    testContractId = randomContractId()
+    testTokenId = testContractId
+    testContractAddress = addressFromContractId(testContractId)
+    testParamsFixture = {
+      // a random address that the test contract resides in the tests
+      address: testContractAddress,
+      // assets owned by the test contract before a test
+      initialAsset: { alphAmount: 10n ** 18n, tokens: [{ id: testTokenId, amount: 10n }] },
+      // initial state of the test contract
+      initialFields: {
+        symbol: Buffer.from('TF', 'utf8').toString('hex'),
+        name: Buffer.from('TokenFaucet', 'utf8').toString('hex'),
+        decimals: 18n,
+        supply: 10n ** 18n,
+        balance: 10n
+      },
+      // arguments to test the target function of the test contract
+      testArgs: { amount: 1n },
+      // assets owned by the caller of the function
+      inputAssets: [{ address: testAddress, asset: { alphAmount: 10n ** 18n } }]
+    }
+  })
+  //See more test in `test/token.test.ts`
+)}
+```
+
+You can run them with:
 
 ```
 npm run test
@@ -71,7 +209,41 @@ npx @alephium/cli@latest test
 
 ## Deploy your contract
 
-Next, to deploy the contract we will use Alephium CLI and a deployment script `scripts/0_deploy_faucet.ts`. You can run it using:
+Next, to deploy the contract we will use Alephium CLI and a deployment script `scripts/0_deploy_faucet.ts`:
+
+```rust
+import { Deployer, DeployFunction, Network } from '@alephium/cli'
+import { Settings } from '../alephium.config'
+import { TokenFaucet } from '../artifacts/ts'
+
+// This deploy function will be called by cli deployment tool automatically
+// Note that deployment scripts should prefixed with numbers (starting from 0)
+const deployFaucet: DeployFunction<Settings> = async (
+  deployer: Deployer,
+  network: Network<Settings>
+): Promise<void> => {
+  // Get settings
+  const issueTokenAmount = network.settings.issueTokenAmount
+  const result = await deployer.deployContract(TokenFaucet, {
+    // The amount of token to be issued
+    issueTokenAmount: issueTokenAmount,
+    // The initial states of the faucet contract
+    initialFields: {
+      symbol: Buffer.from('TF', 'utf8').toString('hex'),
+      name: Buffer.from('TokenFaucet', 'utf8').toString('hex'),
+      decimals: 18n,
+      supply: issueTokenAmount,
+      balance: issueTokenAmount
+    }
+  })
+  console.log('Token faucet contract id: ' + result.contractId)
+  console.log('Token faucet contract address: ' + result.contractAddress)
+}
+
+export default deployFaucet
+```
+
+You can run it using:
 
 ```
 npx @alephium/cli@latest deploy
@@ -81,7 +253,58 @@ This will deploy the token faucet to all of the 4 groups of Devnet. You could co
 
 ## Interact with the deployed contract
 
-Now, you can build the source code `src/token.ts` with:
+Now, you can build the source code `src/token.ts` :
+
+```typescript
+import { Deployments } from '@alephium/cli'
+import { web3, Project } from '@alephium/web3'
+import { testNodeWallet } from '@alephium/web3-test'
+import configuration from '../alephium.config'
+import { TokenFaucet, Withdraw } from '../artifacts/ts'
+
+async function withdraw() {
+  web3.setCurrentNodeProvider('http://127.0.0.1:22973')
+  // Compile the contracts of the project if they are not compiled
+  Project.build()
+
+  // Attention: test wallet is used for demonstration purpose
+  const signer = await testNodeWallet()
+
+  const deployments = await Deployments.load(configuration, 'devnet')
+
+  // The test wallet has four accounts with one in each address group
+  // The wallet calls withdraw function for all of the address groups
+  for (const account of await signer.getAccounts()) {
+    // Set an active account to prepare and sign transactions
+    await signer.setSelectedAccount(account.address)
+    const accountGroup = account.group
+
+    // Load the metadata of the deployed contract in the right group
+    const deployed = deployments.getDeployedContractResult(accountGroup, 'TokenFaucet')
+    if (deployed === undefined) {
+      console.log(`The contract is not deployed on group ${account.group}`)
+      continue
+    }
+    const tokenId = deployed.contractId
+    const tokenAddress = deployed.contractAddress
+
+    // Submit a transaction to use the transaction script
+    await Withdraw.execute(signer, {
+      initialFields: { token: tokenId, amount: 1n }
+    })
+
+    const faucet = TokenFaucet.at(tokenAddress)
+    // Fetch the latest state of the token contract
+    const state = await faucet.fetchState()
+    console.log(JSON.stringify(state.fields, null, '  '))
+  }
+}
+
+withdraw()
+
+```
+
+Simply run:
 
 ```
 npm run build

--- a/docs/dapps/getting-started.md
+++ b/docs/dapps/getting-started.md
@@ -8,529 +8,90 @@ import UntranslatedPageText from "@site/src/components/UntranslatedPageText";
 
 <UntranslatedPageText />
 
-#Dapps Getting started
-
 This guide will explore the basics of creating an Alephium dApp project.
 
 Prerequisites:
 
 - Write code in [Typescript](https://www.typescriptlang.org/)
 - Operate in a [terminal](https://en.wikipedia.org/wiki/Terminal_emulator)
-- [nodejs](https://nodejs.org/en/) version >= 16 installed
-- `npm` version >= 8 installed
 
-## Create a new dApp project: Token Faucet
+## Create a new dApp project
 
-In this tutorial we will write our first dApp: A token faucet.
+To create the tutorial project, open a new terminal and run:
 
-Create a new project folder and navigate into it:
-
-```sh
-mkdir alephium-faucet-tuto
-cd alephium-faucet-tuto
+```
+npx @alephium/cli@latest init alephium-tutorial
 ```
 
-Let's now create a `contracts` folder where we'll store all our contracts:
+This will create a new directory `alephium-tutorial` and initialize a sample project inside that directory.
 
-```sh
-mkdir contracts
+## Launch the local development network
+
+To compile and test your contracts, it's necessary to launch a local development network by running:
+
+```
+npx @alephium/cli@latest devnet start
 ```
 
-Our first contract we'll be `token.ral` which can be found [here](https://github.com/alephium/nextjs-template/blob/main/contracts/token.ral). You can copy the whole file into your `contracts` folder.
+The Typescript SDK is then able to interact with the network through REST endpoints.
 
-Let's inspect it, piece by piece:
+Alternatively, if you want to create a local development network with explorer support, please use `docker-compose` and follow the instructions in [alphium-stack](https://github.com/alephium/alephium-stack#devnet).
 
-```rust
-import "std/token_interface"
-
-Contract TokenFaucet(
-    symbol: ByteVec,
-    name: ByteVec,
-    decimals: U256,
-    supply: U256,
-    mut balance: U256
-) implements IToken {
-```
-
-The first four fields will be immutable values that store the data required to serve our [IToken interface](https://github.com/alephium/alephium-web3/blob/master/packages/web3/std/token_interface.ral).
-`mut balance` is a mutable value that keeps track of how many tokens are left in this faucet.
-
-You can see that our contract emits an `event` and defines an `error` code. Read the following for more info on [events](https://wiki.alephium.org/ralph/getting-started#events) and [error handling](https://wiki.alephium.org/ralph/getting-started#error-handling).
-
-This is followed by 5 access methods for the different contract's arguments.
-
-The last method is where the magic happens:
-
-```rust
-@using(assetsInContract = true, updateFields = true)
-pub fn withdraw(amount: U256) -> () {
-    // Debug events can be helpful for error analysis
-    emit Debug(`The current balance is ${balance}`)
-
-    // Make sure the amount is valid
-    assert!(amount <= 2, ErrorCodes.InvalidWithdrawAmount)
-    // Functions postfixed with `!` are built-in functions.
-    transferTokenFromSelf!(callerAddress!(), selfTokenId!(), amount)
-    // Ralph does not allow underflow.
-    balance = balance - amount
-
-    // Emit the event defined earlier.
-    emit Withdraw(callerAddress!(), amount)
-}
-```
-
-With the `assert!` we make sure no one takes more than 2 tokens at the same time.  
-`transferTokenFromSelf` will actually perform the transfer of the tokens.  
-We update the `mut balance` field with the new balance. In the case of underflow, an error will be raised and the transaction won't be performed.
-`callerAddress!()` and `selfTokenId!()` are built-in functions, you can read more about them in our [built-in functions page](/ralph/built-in-functions).
 ## Compile your contract
 
-The compiler needs to contact the full node in order to compile the contract, you'll need to use the right information defined while [creating your devnet](/full-node/devnet). If you haven't start it, now it's the time.
-We define the node URL using the following config file: `alephium.config.ts`. 
-Create this file in the root directory of your project and paste the following code:
+Next, change the workspace to the tutorial project:
 
-```typescript
-import { Configuration } from '@alephium/cli'
-
-export type Settings = {}
-
-const configuration: Configuration<Settings> = {
-  defaultNetwork: 'devnet',
-  networks: {
-    devnet: {
-      //Make sure the two values match what's in your devnet configuration
-      nodeUrl: 'http://localhost:22973',
-      networkId: 2
-    }
-  }
-}
-
-export default configuration
+```
+cd alephium-tutorial
 ```
 
-Now, let's compile:
+and compile your contracts:
 
-```sh
+```
 npx @alephium/cli@latest compile
 ```
 
-It may ask you for some confirmation to install the latest `@alephium/cli` package. Select yes to proceed.
+If you take a look at `contracts/`, you should be able to find `token.ral`. The compiled artifacts are in the directory `artifacts`.
 
-Once the above command succeeds, you will notice that a new folder called `artifacts` was created. It contains several files related to your contract. For example, `artifacts/ts/TokenFaucet.ts` produces lots of helper functions like `at`, `fetchState`, `call*`, etc, as well as many test functions.
+This command also generates typescript code based on the compiled artifacts. The generated typescript code are in the directory `artifacts/ts`. You can interact with the alephium blockchain more conveniently by using the generated typescript code.
 
 ## Test your contract
-The SDK provides unit test functionalities, which call the contract by sending a transaction, but instead of changing the blockchain state, it returns the new contract state, transaction outputs, and events.
 
-Install the test framework:
+The sample project comes with tests `test/token.test.ts` for your contract. You can run your tests with:
 
-```sh
-npm install ts-jest @types/jest
+```
+npm run test
 ```
 
-You'll also need our `@alephium/web3` package:
+or
 
-```sh
-npm install @alephium/web3 @alephium/web3-test
 ```
-
-Create a `test` folder:
-
-```sh
-mkdir test
-```
-
-and create the `test/token.test.ts` minimalistic test file with the following contents:
-
-```typescript
-import { web3, Project, addressFromContractId } from '@alephium/web3'
-import { randomContractId, testAddress } from '@alephium/web3-test'
-import { TokenFaucet } from '../artifacts/ts'
-
-describe('unit tests', () => {
-  it('Withdraws 1 token from TokenFaucet', async () => {
-
-    // Use the correct host and port
-    web3.setCurrentNodeProvider('http://127.0.0.1:22973')
-    await Project.build()
-
-    let testContractId = randomContractId()
-    let testParams = {
-      // a random address that the test contract resides in the tests
-      address: addressFromContractId(testContractId),
-      // assets owned by the test contract before a test
-      initialAsset: { alphAmount: 10n ** 18n, tokens: [{ id: testContractId, amount: 10n }] },
-      // initial state of the test contract
-      initialFields: {
-        symbol: Buffer.from('TF', 'utf8').toString('hex'),
-        name: Buffer.from('TokenFaucet', 'utf8').toString('hex'),
-        decimals: 18n,
-        supply: 10n ** 18n,
-        balance: 10n
-      },
-      // arguments to test the target function of the test contract
-      testArgs: { amount: 1n },
-      // assets owned by the caller of the function
-      inputAssets: [{ address: testAddress, asset: { alphAmount: 10n ** 18n } }]
-    }
-
-    const testResult = await TokenFaucet.testWithdrawMethod(testParams)
-    console.log(testResult)
-  })
-})
-```
-
-A more complex test can be found in our [alephium/nextjs-template](https://github.com/alephium/nextjs-template/blob/main/test/token.test.ts) project.
-
-Without entering too much into details, TypeScript needs some configuration to run the test so just create a file called `tsconfig.json` in the root directory of your project and paste the following code:
-
-```json
-{
-  "compilerOptions": {
-    "outDir": "dist",
-    "target": "es2020",
-    "esModuleInterop": true,
-    "module": "commonjs",
-    "resolveJsonModule": true
-  },
-  "exclude": ["node_modules"],
-  "include": ["src/**/*.ts", "test/**/*.ts", "scripts/**/*.ts", "alephium.config.ts", "artifacts/**/*.ts"]
-}
-```
-
-You can now run the test:
-
-```sh
 npx @alephium/cli@latest test
 ```
 
-You should be able to see on your terminal the output of calling the withdraw method.
-
-🎉 Congratulations! Have created your first contract and written a test to call it and test it locally! It's time to deploy your contract.
-
 ## Deploy your contract
 
-Now things are getting serious, we will deploy our contract on our `devnet` :rocket:
+Next, to deploy the contract we will use Alephium CLI and a deployment script `scripts/0_deploy_faucet.ts`. You can run it using:
 
-The `deploy` command will execute all deployment scripts it finds inside the `scripts` folder. Create the `scripts` folder in the root folder of the project:
-
-```sh
-mkdir scripts
 ```
-
-Let's create a deployment script file called `0_deploy_faucet.ts` into the `scripts` folder and paste the following code.  
-Note that deployment scripts should always be prefixed with numbers (starting from `0`).
-
-```typescript
-import { Deployer, DeployFunction, Network } from '@alephium/cli'
-import { Settings } from '../alephium.config'
-import { TokenFaucet } from '../artifacts/ts'
-
-// This deploy function will be called by cli deployment tool automatically
-// Note that deployment scripts should prefixed with numbers (starting from 0)
-const deployFaucet: DeployFunction<Settings> = async (
-  deployer: Deployer
-): Promise<void> => {
-  const issueTokenAmount = 100n
-  const result = await deployer.deployContract(TokenFaucet, {
-    // The amount of token to be issued
-    issueTokenAmount: issueTokenAmount,
-    // The initial states of the faucet contract
-    initialFields: {
-      symbol: Buffer.from('TF', 'utf8').toString('hex'),
-      name: Buffer.from('TokenFaucet', 'utf8').toString('hex'),
-      decimals: 18n,
-      supply: issueTokenAmount,
-      balance: issueTokenAmount
-    }
-  })
-  console.log('Token faucet contract id: ' + result.contractId)
-  console.log('Token faucet contract address: ' + result.contractAddress)
-}
-
-export default deployFaucet
-```
-
-The [deployContract](https://github.com/alephium/alephium-web3/blob/d2b5b63cae015e843aa77b4cf484bc62a070f1d5/packages/cli/src/types.ts#L133-L137) of the `Deployer` takes our contract and deploys it with the correct arguments. You can also add a `taskTag` argument to tag your deployment with a specific name. By default, it will use the contract name, but if you deploy the same contract multiple times with different initial fields, your `.deployment` file will get overridden. Using a specific `taskTag` solves this issue.
-
-From the [DeployContractParams](https://github.com/alephium/alephium-web3/blob/d2b5b63cae015e843aa77b4cf484bc62a070f1d5/packages/web3/src/contract/contract.ts#L1286-L1293) interface, we can see that `initialFields` is mandatory as it contains the arguments for our `TokenFaucet` contract.
-
-With `issueTokenAmount` you can define how many tokens you want to issue, this is required if you want to create a token, otherwise no token-id will be created.
-
-Now, let's deploy!
-
-```sh
 npx @alephium/cli@latest deploy
 ```
 
-...OOPS... It doesn't work???
+This will deploy the token faucet to all of the 4 groups of Devnet. You could configure `alephium.config.ts` to deploy the contract to different networks.
 
-If you got the error `The node chain id x is different from configured chain id y`, go check your `networkId` in the devnet configuration and the `alephium.config.ts` file.
+## Interact with the deployed contract
 
-`No UTXO found` ???
-
-Of course we didn't provide the `how-to-use-my-utxos`, we need to define our [privateKeys](https://github.com/alephium/alephium-web3/blob/d2b5b63cae015e843aa77b4cf484bc62a070f1d5/packages/cli/src/types.ts#L39-L46).
-
-You'll need to export the private keys from our wallet extension (might do it from our other wallets later), make sure to use a wallet with funds, like the one from the genesis allocation of your devnet. 
-If you used the docker way to launch your devnet, it might have work as we are defining [a default private key in our cli package](https://github.com/alephium/alephium-web3/blob/d2b5b63cae015e843aa77b4cf484bc62a070f1d5/packages/cli/src/types.ts#L75) based on the genesis allocation.
-
-Let's update our `alephium.config.ts`
-
-```typescript
-const configuration: Configuration<void> = {
-  defaultNetwork: 'devnet',
-  networks: {
-    devnet: {
-      nodeUrl: 'http://localhost:22973',
-      networkId: 2,
-      //The private key of my genesis address 132mqFF2BuxGigdaMTGSruuW29kmEs2eEGcpquG4YZRNh
-      privateKeys: ['672c8292041176c9056bb0dd1d91d34711ceed2493b5afc83f2012b27df2c559']
-    }
-  }
-}
-```
-
-and retry to deploy:
-
-```sh
-npx @alephium/cli@latest deploy
-```
-
-```sh
-Contracts are compiled already. Loading them from folder "artifacts"
-Deploying contract TokenFaucet
-Deployer - group 1 - 132mqFF2BuxGigdaMTGSruuW29kmEs2eEGcpquG4YZRNh
-Token faucet contract id: d00e9c788ddd572b0c186f0599a264f4c79f009c632c8040b7c5f71bfc0ec301
-Token faucet contract address: 28h7qSmkAAeNyoBuQKGyp1WG8VfdKPePCCFGKwp2Y8yyA
-✅ Deployment scripts executed!
-```
-
-Congratulations! Your contract is deployed. We can check the balance of the contract. Use `curl` and change the contract address based on your deployment result:
-
-```sh
-curl 'http://localhost:22973/addresses/28h7qSmkAAeNyoBuQKGyp1WG8VfdKPePCCFGKwp2Y8yyA/balance'
-```
-
-The response should look like this:
-
-```json
-{
-  "balance": "1000000000000000000",
-  "balanceHint": "1 ALPH",
-  "lockedBalance": "0",
-  "lockedBalanceHint": "0 ALPH",
-  "tokenBalances": [
-    {
-      "id": "d00e9c788ddd572b0c186f0599a264f4c79f009c632c8040b7c5f71bfc0ec301",
-      "amount": "100"
-    }
-  ],
-  "utxoNum": 1
-}
-```
-
-We can see our token id, with the 100 tokens we decided to issue.
-
-Let's check the contract state by first getting the group of our address: 
-
-```sh
-curl 'http://localhost:22973/addresses/28h7qSmkAAeNyoBuQKGyp1WG8VfdKPePCCFGKwp2Y8yyA/group'
-curl 'http://localhost:22973/contracts/28h7qSmkAAeNyoBuQKGyp1WG8VfdKPePCCFGKwp2Y8yyA/state?group=1'
-```
-
-
-Contract state response:
-```json
-{
-  "address": "28h7qSmkAAeNyoBuQKGyp1WG8VfdKPePCCFGKwp2Y8yyA",
-  "bytecode": "050609121b4024402d404a010000000102ce0002010000000102ce0102010000000102ce0202010000000102ce0302010000000102a0000201020101001116000e320c7bb4b11600aba00016002ba10005b416005f",
-  "codeHash": "641343b4f1c08b03969b127b452acc7535cad20231bc32af6c0b5f218dd8ff0c",
-  "initialStateHash": "06595afa695949e915dfc1220dfb47125b01751d9e193f4c5fa1c7fc3566673d",
-  "immFields": [
-    {
-      "type": "ByteVec",
-      "value": "5446"
-    },
-    {
-      "type": "ByteVec",
-      "value": "546f6b656e466175636574"
-    },
-    {
-      "type": "U256",
-      "value": "18"
-    },
-    {
-      "type": "U256",
-      "value": "100"
-    }
-  ],
-  "mutFields": [
-    {
-      "type": "U256",
-      "value": "100"
-    }
-  ],
-  "asset": {
-    "attoAlphAmount": "1000000000000000000",
-    "tokens": [
-      {
-        "id": "d00e9c788ddd572b0c186f0599a264f4c79f009c632c8040b7c5f71bfc0ec301",
-        "amount": "100"
-      }
-    ]
-  }
-}
-```
-
-In the `immFields` we can see our initial `TokenFaucet` arguments (`symbol`, `name`, `decimals`, `supply`). We can also see that `mutFields` contains the current token balance. We'll check that field later after calling the faucet.
-
-The `deploy` command also created a `.deployments.devnet.json` file, with the deployment result. It's important to keep that file to easily interact with the contract, even though all information can be found on the blockchain.
-
-# Interact with the deployed contract
-
-Having a token faucet is nice, getting tokens from it is even better.
-
-We can now write some code to interact with the faucet contract.
-
-We'll need to install our `cli` package and the `typescript` dependency if it's not yet the case:
+Now, you can build the source code `src/token.ts` with:
 
 ```
-npm install @alephium/cli typescript
+npm run build
 ```
 
-We will now see a different option to interact with the blockchain. Previously we were using the `DeployFunction` with our `scripts/<number>_*` files which are automatically deployed with the CLI tool.
-
-Another way is to create a skeleton web application project using TypeScript. Create a `src` folder in the root folder of the project and a file called `tokens.ts` in it with the following contents.
-
-```typescript
-import { Deployments } from '@alephium/cli'
-import { web3, Project, NodeProvider } from '@alephium/web3'
-import { PrivateKeyWallet} from '@alephium/web3-wallet'
-import configuration from '../alephium.config'
-import { TokenFaucet, Withdraw } from '../artifacts/ts'
-
-async function withdraw() {
-
-  //Select our network defined in alephium.config.ts
-  const network = configuration.networks[configuration.defaultNetwork]
-
-  //NodeProvider is an abstraction of a connection to the Alephium network
-  const nodeProvider = new NodeProvider(network.nodeUrl)
-
-  //Sometimes, it's convenient to setup a global NodeProvider for your project:
-  web3.setCurrentNodeProvider(nodeProvider)
-
-  //Connect our wallet, typically in a real application you would connect your web-extension or desktop wallet
-  const wallet = new PrivateKeyWallet({privateKey: '672c8292041176c9056bb0dd1d91d34711ceed2493b5afc83f2012b27df2c559' })
-
-  // Compile the contracts of the project if they are not compiled
-  Project.build()
-
-  //.deployments contains the info of our `TokenFaucet` deployement, as we need to now the contractId and address
-  //This was auto-generated with the `cli deploy` of our `scripts/0_deploy_faucet.ts`
-  const deployments = await Deployments.from('.deployments.devnet.json')
-
-  //Make sure it match your address group
-  const accountGroup = 1
-
-  const deployed = deployments.getDeployedContractResult(accountGroup, 'TokenFaucet')
-
-  if(deployed !== undefined) {
-    const tokenId = deployed.contractId
-    const tokenAddress = deployed.contractAddress
-
-    // Submit a transaction to use the transaction script
-    // It uses our `wallet` to sing the transaction.
-    await Withdraw.execute(wallet, {
-      initialFields: { token: tokenId, amount: 1n }
-    })
-
-    // Fetch the latest state of the token contract, `mut balance` should have change
-    const faucet = TokenFaucet.at(tokenAddress)
-    const state = await faucet.fetchState()
-    console.log(state.fields)
-
-    // Fetch wallet balance see if token is there
-    const balance = await wallet.nodeProvider.addresses.getAddressesAddressBalance(wallet.account.address)
-    console.log(balance)
-  } else {
-    console.log('`deployed` is undefined')
-  }
-}
-
-// Let's perform one withdraw
-withdraw()
-```
-
-For the attentive people, you'll see something new coming from our `artifacts`: [`Withdraw`](https://github.com/alephium/nextjs-template/blob/main/contracts/withdraw.ral) which is a [`TxScript`](https://wiki.alephium.org/ralph/getting-started#txscript) required to interact with the `TokenFaucet` contract. Its code is quite simple. Create a file called `withdraw.ral` in the `contracts` folder and paste the following code:
-
-```rust
-TxScript Withdraw(token: TokenFaucet, amount: U256) {
-    token.withdraw(amount)
-}
-```
-
-We now need to recompile our contracts to get the artifact for `Withdraw`:
-
-```sh
-npx @alephium/cli@latest compile
-```
-
-You can now compile the TypeScript code to JavaScript with:
-
-```sh
-npx tsc --build .
-```
-
-OOPS, you should get an error coming from the `alephium.config.ts`, until now the config was used as a simple JSON, but now `TypeScript` want it to respect its [interface](https://github.com/alephium/alephium-web3/blob/d2b5b63cae015e843aa77b4cf484bc62a070f1d5/packages/cli/src/types.ts#L48-L62). Especially the `networks` is a record that need to contain the 3 `NetworkType`. You can try to fix it by yourself or update your `alephium.config.ts` file with:
-
-```typescript
-import { Configuration } from '@alephium/cli'
-
-export type Settings = {}
-
-const configuration: Configuration<Settings> = {
-  defaultNetwork: 'devnet',
-  networks: {
-    devnet: {
-      nodeUrl: 'http://localhost:22973',
-      networkId: 2, //Use the same as in your devnet configuration
-      privateKeys: ['672c8292041176c9056bb0dd1d91d34711ceed2493b5afc83f2012b27df2c559'],
-      settings: {}
-    },
-    testnet: {
-      nodeUrl: '',
-      privateKeys: [],
-      settings: {}
-    },
-    mainnet: {
-      nodeUrl: '',
-      privateKeys: [],
-      settings: {}
-    }
-  }
-}
-
-export default configuration
-```
-
-Now recompile
-
-```
-npx tsc --build .
-```
-
-A `dist` folder should have been created, go ahead and interact with the deployed token faucet:
+and interact with the deployed token faucet:
 
 ```
 node dist/src/token.js
 ```
-
-You should now be a proud owner of the token you created.
-
-
-## What's next?
-
-You can find a more complex example of the token faucet tutorial [in the alephium/nextjs-template](https://github.com/alephium/nextjs-template) project.
 
 ## Connect to the wallets
 

--- a/docs/dapps/getting-started.md
+++ b/docs/dapps/getting-started.md
@@ -21,23 +21,24 @@ Prerequisites:
 
 In this tutorial we will write our first dApp: A token faucet.
 
-Create a directory for tuto.
+Create a new project folder and navigate into it:
 
 ```sh
 mkdir alephium-faucet-tuto
 cd alephium-faucet-tuto
 ```
 
-Let's now create a `contracts` folder where we'll store all our contracts
+Let's now create a `contracts` folder where we'll store all our contracts:
 
 ```sh
 mkdir contracts
 ```
 
-Our first contract we'll be `token.ral` which can be found [here](https://github.com/alephium/nextjs-template/blob/main/contracts/token.ral), you can copy it into your `contracts` folder.
-Let's dive into it.
+Our first contract we'll be `token.ral` which can be found [here](https://github.com/alephium/nextjs-template/blob/main/contracts/token.ral). You can copy the whole file into your `contracts` folder.
 
-```
+Let's inspect it, piece by piece:
+
+```rust
 import "std/token_interface"
 
 Contract TokenFaucet(
@@ -49,14 +50,14 @@ Contract TokenFaucet(
 ) implements IToken {
 ```
 
-The first four fields will be immutable values that store the data required to served our [IToken interface](https://github.com/alephium/alephium-web3/blob/master/packages/web3/std/token_interface.ral).
-`mut balance` is a mutable value that keep track on how many tokens are left in this faucet.
+The first four fields will be immutable values that store the data required to serve our [IToken interface](https://github.com/alephium/alephium-web3/blob/master/packages/web3/std/token_interface.ral).
+`mut balance` is a mutable value that keeps track of how many tokens are left in this faucet.
 
-You can see that our contract is emitting some `event` and define an `error` code. Read the following for more info on the [events](https://wiki.alephium.org/ralph/getting-started#events) and the [error handling](https://wiki.alephium.org/ralph/getting-started#error-handling).
+You can see that our contract emits an `event` and defines an `error` code. Read the following for more info on [events](https://wiki.alephium.org/ralph/getting-started#events) and [error handling](https://wiki.alephium.org/ralph/getting-started#error-handling).
 
-This is followed by five access method for the different contract's arguments.
+This is followed by 5 access methods for the different contract's arguments.
 
-The latest function is where the magic happen:
+The last method is where the magic happens:
 
 ```rust
 @using(assetsInContract = true, updateFields = true)
@@ -76,13 +77,13 @@ pub fn withdraw(amount: U256) -> () {
 }
 ```
 
-With the `assert!` We make sure no one take more than 2 tokens at the same time.
-`transferTokenFromSelf` will actually perform the transfer of token.
-We update the `mut balance` field with the new balance, if it goes underflow and error will be raised and the transaction won't be perform.
-
+With the `assert!` we make sure no one takes more than 2 tokens at the same time.  
+`transferTokenFromSelf` will actually perform the transfer of the tokens.  
+We update the `mut balance` field with the new balance. In the case of underflow, an error will be raised and the transaction won't be performed.
+`callerAddress!()` and `selfTokenId!()` are built-in functions, you can read more about them in our [built-in functions page](/ralph/built-in-functions).
 ## Compile your contract
 
-The compiler needs to contact the full node in order to compile, we define the node url using with the following config file: `alephium.config.ts`
+The compiler needs to contact the full node in order to compile the contract. We define the node URL using the following config file: `alephium.config.ts`. Create this file in the root directory of your project and paste the following code:
 
 ```typescript
 import { Configuration } from '@alephium/cli'
@@ -103,18 +104,18 @@ export default configuration
 
 Make sure to use the correct host and port.
 
-Now let's compile:
+Now, let's compile:
 
 ```sh
 npx @alephium/cli@latest compile
 ```
 
-It may ask you some confirmation to install the latest `@alephium/cli` package.
+It may ask you for some confirmation to install the latest `@alephium/cli` package. Select yes to proceed.
 
-You can check the produced result into `artifacts`. For example `artifacts/ts/TokenFaucet.ts` produce lots of helper functions: `at, fetchState, call*, etc`, as well as test functions.
+Once the above command succeeds, you will notice that a new folder called `artifacts` was created. It contains several files related to your contract. For example, `artifacts/ts/TokenFaucet.ts` produces lots of helper functions like `at`, `fetchState`, `call*`, etc, as well as many test functions.
 
 ## Test your contract
-The SDK provides unit test functionalities, which calls the contract like a normal transaction, but instead of changing the blockchain state, it returns the new contract state, transaction outputs, and events.
+The SDK provides unit test functionalities, which call the contract by sending a transaction, but instead of changing the blockchain state, it returns the new contract state, transaction outputs, and events.
 
 Install the test framework:
 
@@ -122,7 +123,7 @@ Install the test framework:
 npm install ts-jest @types/jest
 ```
 
-You'll also need our `web3` package
+You'll also need our `@alephium/web3` package:
 
 ```sh
 npm install @alephium/web3 @alephium/web3-test
@@ -134,7 +135,7 @@ Create a `test` folder:
 mkdir test
 ```
 
-and add this minimal test: `test/token.test.ts`
+and create the `test/token.test.ts` minimalistic test file with the following contents:
 
 ```typescript
 import { web3, Project, addressFromContractId } from '@alephium/web3'
@@ -142,7 +143,7 @@ import { randomContractId, testAddress } from '@alephium/web3-test'
 import { TokenFaucet } from '../artifacts/ts'
 
 describe('unit tests', () => {
-  it('test withdraw', async () => {
+  it('Withdraws 1 token from TokenFaucet', async () => {
 
     // Use the correct host and port
     web3.setCurrentNodeProvider('http://127.0.0.1:22973')
@@ -174,9 +175,9 @@ describe('unit tests', () => {
 })
 ```
 
-A more complex test can be found [here](https://github.com/alephium/nextjs-template/blob/main/test/token.test.ts)
+A more complex test can be found in our [alephium/nextjs-template](https://github.com/alephium/nextjs-template/blob/main/test/token.test.ts) project.
 
-Without entering to much into details, `Typescript` needs some configuration to run the test, just copy the following into `tsconfig.json`
+Without entering too much into details, TypeScript needs some configuration to run the test so just create a file called `tsconfig.json` in the root directory of your project and paste the following code:
 
 ```json
 {
@@ -198,20 +199,22 @@ You can now run the test:
 npx @alephium/cli@latest test
 ```
 
-Congratulations, you should see what result would produce a withdraw.
+You should be able to see on your terminal the output of calling the withdraw method.
+
+🎉 Congratulations! Have created your first contract and written a test to call it and test it locally! It's time to deploy your contract.
 
 ## Deploy your contract
 
 Now things are getting serious, we will deploy our contract on our `devnet` :rocket:
 
-The `deploy` command will deploy everything which is inside the `scripts` folder.
+The `deploy` command will execute all deployment scripts it finds inside the `scripts` folder. Create the `scripts` folder in the root folder of the project:
 
 ```sh
 mkdir scripts
 ```
 
-Let's create this file into this folder: `scripts/0_deploy_faucet.ts`
-Note that deployment scripts should prefixed with numbers (starting from 0)
+Let's create a deployment script file called `0_deploy_faucet.ts` into the `scripts` folder and paste the following code.  
+Note that deployment scripts should always be prefixed with numbers (starting from `0`).
 
 ```typescript
 import { Deployer, DeployFunction, Network } from '@alephium/cli'
@@ -243,13 +246,13 @@ const deployFaucet: DeployFunction<Settings> = async (
 export default deployFaucet
 ```
 
-[deployContract](https://github.com/alephium/alephium-web3/blob/d2b5b63cae015e843aa77b4cf484bc62a070f1d5/packages/cli/src/types.ts#L133-L137) takes our contract and deploy it with the correct arguments, you can also add a `taskTag` arguments, to tag your deployment with a specific name. By default it will use the contract name, but if you deploy multiple time the same contract with different initial fields, your `.deployement` file will get override, using a specific `taskTag` solve this issue.
+The [deployContract](https://github.com/alephium/alephium-web3/blob/d2b5b63cae015e843aa77b4cf484bc62a070f1d5/packages/cli/src/types.ts#L133-L137) of the `Deployer` takes our contract and deploys it with the correct arguments. You can also add a `taskTag` argument to tag your deployment with a specific name. By default, it will use the contract name, but if you deploy the same contract multiple times with different initial fields, your `.deployment` file will get overridden. Using a specific `taskTag` solves this issue.
 
 From the [DeployContractParams](https://github.com/alephium/alephium-web3/blob/d2b5b63cae015e843aa77b4cf484bc62a070f1d5/packages/web3/src/contract/contract.ts#L1286-L1293) interface, we can see that `initialFields` is mandatory as it contains the arguments for our `TokenFaucet` contract.
 
 With `issueTokenAmount` you can define how many tokens you want to issue, this is required if you want to create a token, otherwise no token-id will be created.
 
-Now let's deploy!!!
+Now, let's deploy!
 
 ```sh
 npx @alephium/cli@latest deploy
@@ -295,14 +298,13 @@ Token faucet contract address: 28h7qSmkAAeNyoBuQKGyp1WG8VfdKPePCCFGKwp2Y8yyA
 ✅ Deployment scripts executed!
 ```
 
-Congratulations! Your contract is deployed. We can check the balance of the contract:
-Change the contract address base on your deployment result
+Congratulations! Your contract is deployed. We can check the balance of the contract. Use `curl` and change the contract address based on your deployment result:
 
 ```sh
 curl 'http://localhost:22973/addresses/28h7qSmkAAeNyoBuQKGyp1WG8VfdKPePCCFGKwp2Y8yyA/balance'
 ```
 
-Response:
+The response should look like this:
 
 ```json
 {
@@ -320,15 +322,15 @@ Response:
 }
 ```
 
-We can see our token id, with the 100 token we decided to issue.
+We can see our token id, with the 100 tokens we decided to issue.
 
-Let's check the contract state:
+Let's check the contract state by first getting the group of our address: 
 
 ```sh
+curl 'http://localhost:22973/addresses/28h7qSmkAAeNyoBuQKGyp1WG8VfdKPePCCFGKwp2Y8yyA/group'
 curl 'http://localhost:22973/contracts/28h7qSmkAAeNyoBuQKGyp1WG8VfdKPePCCFGKwp2Y8yyA/state?group=1'
 ```
 
-The `group` value may vary depending of your deploying address. You can always get your group number with the `curl 'http://localhost:22973/addresses/<your-address>/group'`  endpoint.
 
 Contract state response:
 ```json
@@ -373,9 +375,9 @@ Contract state response:
 }
 ```
 
-In the `immFields` we can find back our `TokenFaucet` initial arguments, `symbol/name/decimals/supply` and the `mutFields` contains the current token balance, we'll check latter that field after calling the faucet.
+In the `immFields` we can see our initial `TokenFaucet` arguments (`symbol`, `name`, `decimals`, `supply`). We can also see that `mutFields` contains the current token balance. We'll check that field later after calling the faucet.
 
-The `deploy` command also create a `.deployments.devnet.json` file, with the deployment result. It's important to keep that file to easily interact latter with the contract, even tho all informations can be found back on the blockchain.
+The `deploy` command also created a `.deployments.devnet.json` file, with the deployment result. It's important to keep that file to easily interact with the contract, even though all information can be found on the blockchain.
 
 # Interact with the deployed contract
 
@@ -389,7 +391,7 @@ We'll need to install our `cli` package and the `typescript` dependency if it's 
 npm install @alephium/cli typescript
 ```
 
-We will now see another way to interact with the blockchain, previously we were using the `DeployFunction` with our `scripts/x_*` files. Which are automatically deploy with the cli tool.
+We will now see another way to interact with the blockchain. Previously we were using the `DeployFunction` with our `scripts/<number>_*` files which are automatically deployed with the CLI tool.
 
 The next way is a skeleton of what you could do for a web-application.
 This will be a `TypeScript` application and code goes into the `src` folder.
@@ -460,7 +462,7 @@ async function withdraw() {
 withdraw()
 ```
 
-For the attentive people, you'll see something new coming from our `artifacts`: [Withdraw](https://github.com/alephium/nextjs-template/blob/main/contracts/withdraw.ral) which is a [TxScript](https://wiki.alephium.org/ralph/getting-started#txscript) required to interact with the `TokenFaucet` contract. Its code is quite simple, you can add this to you `contracts/withdraw.ral`
+For the attentive people, you'll see something new coming from our `artifacts`: [`Withdraw`](https://github.com/alephium/nextjs-template/blob/main/contracts/withdraw.ral) which is a [`TxScript`](https://wiki.alephium.org/ralph/getting-started#txscript) required to interact with the `TokenFaucet` contract. Its code is quite simple. Create a file called `withdraw.ral` in the `contracts` folder and paste the following code:
 
 ```rust
 TxScript Withdraw(token: TokenFaucet, amount: U256) {
@@ -468,7 +470,7 @@ TxScript Withdraw(token: TokenFaucet, amount: U256) {
 }
 ```
 
-We now need to recompile our contracts to get the artifact for `Withdraw`
+We now need to recompile our contracts to get the artifact for `Withdraw`:
 
 ```sh
 npx @alephium/cli@latest compile
@@ -476,7 +478,7 @@ npx @alephium/cli@latest compile
 
 The code of `token.ts` should be self-explanatory, you can read more on our [web3-sdk here](https://wiki.alephium.org/dapps/alephium-web3)
 
-You can now try to compile.
+You can now compile the TypeScript code to JavaScript with:
 
 ```sh
 npx tsc --build .
@@ -531,7 +533,7 @@ You should now be a proud owner of the token you created.
 
 ## What's next?
 
-You can find a more complex example of the token faucet tutorial [here](https://github.com/alephium/nextjs-template)
+You can find a more complex example of the token faucet tutorial [in the alephium/nextjs-template](https://github.com/alephium/nextjs-template) project.
 
 ## Connect to the wallets
 

--- a/docs/explorer-backend/getting-started.md
+++ b/docs/explorer-backend/getting-started.md
@@ -12,7 +12,7 @@ sidebar_label: Getting started
 
 ## Download Application File
 
-Download file `explorer-backend-1.x.x.jar` from [Github release](https://github.com/alephium/explorer-backend/releases/latest).
+Download file `explorer-backend-x.x.x.jar` from [Github release](https://github.com/alephium/explorer-backend/releases/latest).
 
 ## Create the database:
 
@@ -38,7 +38,7 @@ Download file `explorer-backend-1.x.x.jar` from [Github release](https://github.
 ## Start your exlporer-backend
 
 ```shell
-java -jar explorer-backend-1.x.x.jar
+java -jar explorer-backend-x.x.x.jar
 ```
 
 Your explorer-backend will start to sync with the full node. It might take long the first time

--- a/docs/full-node/devnet.md
+++ b/docs/full-node/devnet.md
@@ -26,7 +26,7 @@ Alternatively, if you want to create a local development network with explorer s
 
 ### Full node
 
-Download file `alephium-1.x.x.jar` from [Github release](https://github.com/alephium/alephium/releases/latest) (do not double click on it, it can not be launched this way).
+Download file `alephium-x.x.x.jar` from [Github release](https://github.com/alephium/alephium/releases/latest) (do not double click on it, it can not be launched this way).
 
 Write the minimum config file `~/.alephium/user.conf`
 
@@ -77,7 +77,7 @@ You can now access the full node's API at: `http://localhost:22973/docs`
 
 Requirement: https://www.postgresql.org/
 
-Download file `explorer-backend-1.x.x.jar` from [Github release](https://github.com/alephium/explorer-backend/releases/latest)
+Download file `explorer-backend-x.x.x.jar` from [Github release](https://github.com/alephium/explorer-backend/releases/latest)
 
 Connect to PostgreSQL and create a database for your devnet
 
@@ -91,4 +91,4 @@ You can check [the configuration file](https://github.com/alephium/explorer-back
 export BLOCKFLOW_NETWORK_ID=2
 export BLOCKFLOW_PORT=22973
 export DB_NAME=devnet
-java -jar explorer-backend-1.13.0.jar
+java -jar explorer-backend-x.x.x.jar

--- a/docs/full-node/devnet.md
+++ b/docs/full-node/devnet.md
@@ -1,0 +1,92 @@
+---
+sidebar_position: 50
+title: Devnet
+sidebar_label: Devnet
+---
+
+import UntranslatedPageText from "@site/src/components/UntranslatedPageText";
+
+<UntranslatedPageText />
+
+# Create a local Devnet
+
+## Using Docker
+
+```sh
+npx @alephium/cli@latest devnet start
+```
+
+The Typescript SDK is then able to interact with the network through REST endpoints.
+
+Alternatively, if you want to create a local development network with explorer support, please use `docker-compose` and follow the instructions in [alphium-stack](https://github.com/alephium/alephium-stack#devnet).
+
+## Using jar files
+
+### Full node
+
+Download file `alephium-1.x.x.jar` from [Github release](https://github.com/alephium/alephium/releases/latest) (do not double click on it, it can not be launched this way).
+
+Write the minimum config file `~/.alephium/user.conf`
+
+```conf
+alephium {
+
+  network = {
+    network-id = 2
+    rest-port = 22973
+  }
+
+  discovery.bootstrap = []
+
+  broker {
+    groups = 4
+    broker-num = 1
+    broker-id = 0
+  }
+
+  genesis.allocations = [
+    {
+      # wife tone decline assault address repair identify paper color taxi miss crucial resist rebuild man enforce ocean swim nuclear gallery clay hold armed green
+      address = "132mqFF2BuxGigdaMTGSruuW29kmEs2eEGcpquG4YZRNh",
+      amount = "1000000 ALPH",
+      lock-duration = 0 days
+    }
+  ]
+
+  mempool {
+    auto-mine-for-dev = true
+  }
+}
+```
+
+Note: The mnemonic (24 words) and the corresponding address were created for this tutorial, you can use it or create your own, but never use it on `mainnet`.
+      You can also add more addresses if you want. If you want change the addresses afterward, you'll need to erase and restart your devnet.
+
+
+You can now start your `devnet`:
+
+```sh
+java -jar alephium-x.x.x.jar
+```
+
+You can now access the full node's API at: `http://localhost:22973/docs`
+
+### Explorer-backend
+
+Requirement: https://www.postgresql.org/
+
+Download file `explorer-backend-1.x.x.jar` from [Github release](https://github.com/alephium/explorer-backend/releases/latest)
+
+Connect to PostgreSQL and create a database for your devnet
+
+```sql
+CREATE DATABASE devnet;
+```
+
+You can check [the configuration file](https://github.com/alephium/explorer-backend/blob/feature/contract-subcontract/app/src/main/resources/application.conf) to see what settings can be override. You can then configure and launch your `explorer-backend` with:
+
+```sh
+export BLOCKFLOW_NETWORK_ID=2
+export BLOCKFLOW_PORT=22973
+export DB_NAME=devnet
+java -jar explorer-backend-1.13.0.jar

--- a/docs/full-node/devnet.md
+++ b/docs/full-node/devnet.md
@@ -10,6 +10,10 @@ import UntranslatedPageText from "@site/src/components/UntranslatedPageText";
 
 # Create a local Devnet
 
+## Using Docker
+
+If you want to create a local development network with explorer support, please use `docker-compose` and follow the instructions in [alphium-stack](https://github.com/alephium/alephium-stack#devnet).
+
 ## Automatically with our development tool
 
 ```sh
@@ -119,7 +123,3 @@ export BLOCKFLOW_PORT=22973
 export DB_NAME=devnet
 java -jar explorer-backend-x.x.x.jar
 ```
-
-## Using Docker
-
-If you want to create a local development network with explorer support, please use `docker-compose` and follow the instructions in [alphium-stack](https://github.com/alephium/alephium-stack#devnet).

--- a/docs/full-node/devnet.md
+++ b/docs/full-node/devnet.md
@@ -10,7 +10,7 @@ import UntranslatedPageText from "@site/src/components/UntranslatedPageText";
 
 # Create a local Devnet
 
-## Using Docker
+## Automatically with our development tool
 
 ```sh
 npx @alephium/cli@latest devnet start
@@ -20,9 +20,7 @@ This launch a devnet with [this configuration](https://github.com/alephium/aleph
 
 The Typescript SDK is then able to interact with the network through REST endpoints.
 
-Alternatively, if you want to create a local development network with explorer support, please use `docker-compose` and follow the instructions in [alphium-stack](https://github.com/alephium/alephium-stack#devnet).
-
-## Using jar files
+## Manually using jar files
 
 ### Full node
 
@@ -120,3 +118,8 @@ export BLOCKFLOW_NETWORK_ID=2
 export BLOCKFLOW_PORT=22973
 export DB_NAME=devnet
 java -jar explorer-backend-x.x.x.jar
+```
+
+## Using Docker
+
+If you want to create a local development network with explorer support, please use `docker-compose` and follow the instructions in [alphium-stack](https://github.com/alephium/alephium-stack#devnet).

--- a/docs/full-node/devnet.md
+++ b/docs/full-node/devnet.md
@@ -28,40 +28,68 @@ Alternatively, if you want to create a local development network with explorer s
 
 Download file `alephium-x.x.x.jar` from [Github release](https://github.com/alephium/alephium/releases/latest) (do not double click on it, it can not be launched this way).
 
-Write the minimum config file `~/.alephium/user.conf`
+Write a configuration file at `~/.alephium/user.conf`, the one below is taken from our [alephium-stack repo](https://github.com/alephium/alephium-stack/blob/master/devnet/devnet.conf)
 
 ```conf
-alephium {
+# Import this mnemonic to have 4'000'000 token allocated for your addresses
+#
+# vault alarm sad mass witness property virus style good flower rice alpha viable evidence run glare pretty scout evil judge enroll refuse another lava
 
-  network = {
-    network-id = 2
-    rest-port = 22973
+alephium.genesis.allocations = [
+  {
+    address = "1DrDyTr9RpRsQnDnXo2YRiPzPW4ooHX5LLoqXrqfMrpQH",
+    amount = 1000000000000000000000000,
+    lock-duration = 0 seconds
+  },
+  {
+    address = "14UAjZ3qcmEVKdTo84Kwf4RprTQi86w2TefnnGFjov9xF",
+    amount = 1000000000000000000000000,
+    lock-duration = 0 seconds
+  },
+  {
+    address = "15jjExDyS8q3Wqk9v29PCQ21jDqubDrD8WQdgn6VW2oi4",
+    amount = 1000000000000000000000000,
+    lock-duration = 0 seconds
+  },
+  {
+    address = "17cBiTcWhung3WDLuc9ja5Y7BMus5Q7CD9wYBxS1r1P2R",
+    amount = 1000000000000000000000000,
+    lock-duration = 0 seconds
   }
+]
 
-  discovery.bootstrap = []
+alephium.consensus.num-zeros-at-least-in-hash = 0
+alephium.consensus.uncle-dependency-gap-time = 0 seconds
+alephium.network.leman-hard-fork-timestamp = 1643500800000 # GMT: 30 January 2022 00:00:00
 
-  broker {
-    groups = 4
-    broker-num = 1
-    broker-id = 0
-  }
+alephium.network.network-id = 4
+alephium.discovery.bootstrap = []
+alephium.wallet.locking-timeout = 99999 minutes
+alephium.mempool.auto-mine-for-dev = true
+alephium.node.event-log.enabled=true
+alephium.node.event-log.index-by-tx-id = true
+alephium.node.event-log.index-by-block-hash = true
 
-  genesis.allocations = [
-    {
-      # wife tone decline assault address repair identify paper color taxi miss crucial resist rebuild man enforce ocean swim nuclear gallery clay hold armed green
-      address = "132mqFF2BuxGigdaMTGSruuW29kmEs2eEGcpquG4YZRNh",
-      amount = "1000000 ALPH",
-      lock-duration = 0 days
-    }
-  ]
+alephium.network.rest-port = 22973
+alephium.network.ws-port = 21973
+alephium.network.miner-api-port = 20973
+alephium.api.network-interface = "0.0.0.0"
+alephium.api.api-key-enabled = false
+alephium.mining.api-interface = "0.0.0.0"
+alephium.network.bind-address  = "0.0.0.0:19973"
+alephium.network.internal-address  = "alephium:19973"
+alephium.network.coordinator-address  = "alephium:19973"
 
-  mempool {
-    auto-mine-for-dev = true
-  }
-}
+# arbitrary mining addresses
+alephium.mining.miner-addresses = [
+  "1FsroWmeJPBhcPiUr37pWXdojRBe6jdey9uukEXk1TheA",
+  "1CQvSXsmM5BMFKguKDPpNUfw1idiut8UifLtT8748JdHc",
+  "193maApeJWrz9GFwWCfa982ccLARVE9Y1WgKSJaUs7UAx",
+  "16fZKYPCZJv2TP3FArA9FLUQceTS9U8xVnSjxFG9MBKyY"
+]
 ```
 
-Note: The mnemonic (24 words) and the corresponding address were created for this tutorial, you can use it or create your own, but never use it on `mainnet`.
+Note: The mnemonic (24 words) and the corresponding addresses were created for development purposes, you can use it or create your own, but never use it on `mainnet`.
       You can also add more addresses if you want. If you want change the addresses afterward, you'll need to erase and restart your devnet.
 
 

--- a/docs/full-node/devnet.md
+++ b/docs/full-node/devnet.md
@@ -16,6 +16,8 @@ import UntranslatedPageText from "@site/src/components/UntranslatedPageText";
 npx @alephium/cli@latest devnet start
 ```
 
+This launch a devnet with [this configuration](https://github.com/alephium/alephium-web3/blob/master/packages/cli/devnet-user.conf)
+
 The Typescript SDK is then able to interact with the network through REST endpoints.
 
 Alternatively, if you want to create a local development network with explorer support, please use `docker-compose` and follow the instructions in [alphium-stack](https://github.com/alephium/alephium-stack#devnet).

--- a/docs/full-node/full-node-more.md
+++ b/docs/full-node/full-node-more.md
@@ -53,7 +53,7 @@ To fix the problem:
 
 1. Delete the folder .alephium `rm .alephium`
 
-2. Restart the node and wait for synchronization `java -jar alephium-1.x.x.jar`
+2. Restart the node and wait for synchronization `java -jar alephium-x.x.x.jar`
 
 ## Moving the Alephium data folder
 
@@ -77,11 +77,11 @@ There are several environment variables used for logging:
 Below is an example with all of the possible logging options:
 
 ```
-ALEPHIUM_HOM=<folder> ALEPHIUM_LOG_LEVEL=<DEBUG | INFO | WARN | ERROR> ALEPHIUM_ENABLE_DEBUG_LOGGING=<true | false> java -jar alephium-1.x.x.jar
+ALEPHIUM_HOM=<folder> ALEPHIUM_LOG_LEVEL=<DEBUG | INFO | WARN | ERROR> ALEPHIUM_ENABLE_DEBUG_LOGGING=<true | false> java -jar alephium-x.x.x.jar
 ```
 
 It's also possible to override the [logging configuration file](https://github.com/alephium/alephium/blob/master/flow/src/main/resources/logback.xml) of Alephium.
 
 ```
-java -Dlogback.configurationFile=/path/to/config.xml alephium-1.x.x.jar
+java -Dlogback.configurationFile=/path/to/config.xml alephium-x.x.x.jar
 ```

--- a/docs/full-node/getting-started.md
+++ b/docs/full-node/getting-started.md
@@ -17,15 +17,15 @@ Ensure that Java (11 or 17 is recommended) is installed on your computer:
 
 ## Download Application File
 
-Download file `alephium-1.x.x.jar` from [Github release](https://github.com/alephium/alephium/releases/latest) (do not double click on it, it can not be launched this way).
+Download file `alephium-x.x.x.jar` from [Github release](https://github.com/alephium/alephium/releases/latest) (do not double click on it, it can not be launched this way).
 
 ## Start your node
 
 1. Open the search and type in `Terminal` (for Mac and Ubuntu) or `Command Prompt` (for Windows).
-2. In the Terminal/Command Prompt program, type `cd your-jar-file-path` to enter the folder in which the **alephium-1.x.x.jar** file is saved.
+2. In the Terminal/Command Prompt program, type `cd your-jar-file-path` to enter the folder in which the **alephium-x.x.x.jar** file is saved.
 3. Type the following command and press Enter to launch the full node:
    ```shell
-   java -jar alephium-1.x.x.jar
+   java -jar alephium-x.x.x.jar
    ```
 
 🎉 _**Tada, your node is running**_

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -135,6 +135,7 @@ const config = {
       prism: {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
+        additionalLanguages: ['bash', 'rust'],
       },
       algolia: {
         appId: "BN8IMFOF55",

--- a/i18n/fr/docusaurus-plugin-content-docs/current/full-node/full-node-more.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/full-node/full-node-more.md
@@ -40,7 +40,7 @@ Pour résoudre le problème :
 
 1. Supprimez le dossier .alephium `rm .alephium`.
 
-2. Redémarrez le noeud et attendez la synchronisation `java -jar alephium-1.x.x.jar`.
+2. Redémarrez le noeud et attendez la synchronisation `java -jar alephium-x.x.x.jar`.
 
 ## Déplacer le dossier de données d'Alephium
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/full-node/getting-started.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/full-node/getting-started.md
@@ -19,15 +19,15 @@ Assurez-vous que Java (11 ou 17 est recommandé) est installé sur votre ordinat
 
 ## Télécharger le fichier d'application
 
-Téléchargez le fichier `alephium-1.x.x.jar` depuis [Github release](https://github.com/alephium/alephium/releases/latest) (ne double-cliquez pas dessus, il ne peut pas être lancé de cette façon).
+Téléchargez le fichier `alephium-x.x.x.jar` depuis [Github release](https://github.com/alephium/alephium/releases/latest) (ne double-cliquez pas dessus, il ne peut pas être lancé de cette façon).
 
 ## Démarrez votre noeud
 
 1. Ouvrez la recherche et tapez `Terminal` (pour Mac et Ubuntu) ou `Command Prompt` (pour Windows).
-2. Dans le programme Terminal/Command Prompt, tapez `cd your-jar-file-path` pour entrer dans le dossier dans lequel le fichier **alephium-1.x.x.jar** est enregistré.
+2. Dans le programme Terminal/Command Prompt, tapez `cd your-jar-file-path` pour entrer dans le dossier dans lequel le fichier **alephium-x.x.x.jar** est enregistré.
 3. Tapez la commande suivante et appuyez sur Entrée pour lancer le nœud complet :
    ```shell
-   java -jar alephium-1.x.x.jar
+   java -jar alephium-x.x.x.jar
    ```
 
 🎉 _**Tada, votre nœud est en cours d'exécution**_


### PR DESCRIPTION
See the new tutorial a nicer way [here](https://github.com/alephium/docs/blob/8e569332407406e00408557ac9bb45370acf2524/docs/dapps/getting-started.md)

While trying to learn dapps, I  followed our getting started tutorial, but after finishing it I feel  like I didn't understood anything and couldn't start writing my own dapps, as I was just executing `npx` command and everything was done for me.

For this PR I took a good amount of time rewriting the `Token Faucet` dapp. In this new tutorial we explicitly tell the reader each line of code he has to write to have a good overview on the all process. 

I really go with the minimal amount of stuff you need to make it works, I cleaned and removed everything that was not mandatory. At the end we redirect the user to the more complete example of the token faucet .

Thx to this, I could actually deploy [our 5 test tokens](https://github.com/alephium/token-list/blob/master/tokens/testnet.json) on our testnet. 