### PR TITLE
Introduce v20 endpoints which will remain the only ones after Leman upgrade

### DIFF
--- a/docs/dapps/public-services.md
+++ b/docs/dapps/public-services.md
@@ -33,9 +33,11 @@ Mind that the faucet is throttling requests for few minutes.
 ## Node and Explorer APIs
 
 Currently, the following API services are maintained. Note that all APIs are rate limited to prevent spam.
-* `https://wallet-v16.mainnet.alephium.org` for mainnet with node v1.6.X, deprecated ([Test](https://wallet-v16.mainnet.alephium.org/infos/version))
-* `https://wallet-v17.mainnet.alephium.org` for mainnet with node v1.7.X ([Test](https://wallet-v17.mainnet.alephium.org/infos/version))
-* `https://wallet-v17.testnet.alephium.org` for testnet with node v1.7.X ([Test](https://wallet-v17.testnet.alephium.org/infos/version))
+* `https://wallet-v16.mainnet.alephium.org` for mainnet with node v1.6.X, deprecated, removed after Leman upgrade ([Test](https://wallet-v16.mainnet.alephium.org/infos/version))
+* `https://wallet-v17.mainnet.alephium.org` for mainnet with node v1.7.X, removed after Leman upgrade. ([Test](https://wallet-v17.mainnet.alephium.org/infos/version))
+* `https://wallet-v20.mainnet.alephium.org` for mainnet with node v2.X ([Test](https://wallet-v20.mainnet.alephium.org/infos/version))
+* `https://wallet-v17.testnet.alephium.org` for testnet with node v1.7.X, deprecated ([Test](https://wallet-v17.testnet.alephium.org/infos/version))
+* `https://wallet-v20.testnet.alephium.org` for testnet with node v1.7.X ([Test](https://wallet-v207.testnet.alephium.org/infos/version))
 * `https://backend-v112.mainnet.alephium.org` for mainnet with explorer backend v1.12.X, deprecated ([Test](https://backend-v112.mainnet.alephium.org/infos))
 * `https://backend-v113.mainnet.alephium.org` for mainnet with explorer backend v1.13.X ([Test](https://backend-v113.mainnet.alephium.org/infos))
 * `https://backend-v112.testnet.alephium.org` for testnet with explorer backend v1.12.X, deprecated ([Test](https://backend-v112.testnet.alephium.org/infos))

--- a/docs/dapps/public-services.md
+++ b/docs/dapps/public-services.md
@@ -37,7 +37,7 @@ Currently, the following API services are maintained. Note that all APIs are rat
 * `https://wallet-v17.mainnet.alephium.org` for mainnet with node v1.7.X, removed after Leman upgrade. ([Test](https://wallet-v17.mainnet.alephium.org/infos/version))
 * `https://wallet-v20.mainnet.alephium.org` for mainnet with node v2.X ([Test](https://wallet-v20.mainnet.alephium.org/infos/version))
 * `https://wallet-v17.testnet.alephium.org` for testnet with node v1.7.X, deprecated ([Test](https://wallet-v17.testnet.alephium.org/infos/version))
-* `https://wallet-v20.testnet.alephium.org` for testnet with node v1.7.X ([Test](https://wallet-v207.testnet.alephium.org/infos/version))
+* `https://wallet-v20.testnet.alephium.org` for testnet with node v2.X ([Test](https://wallet-v20.testnet.alephium.org/infos/version))
 * `https://backend-v112.mainnet.alephium.org` for mainnet with explorer backend v1.12.X, deprecated ([Test](https://backend-v112.mainnet.alephium.org/infos))
 * `https://backend-v113.mainnet.alephium.org` for mainnet with explorer backend v1.13.X ([Test](https://backend-v113.mainnet.alephium.org/infos))
 * `https://backend-v112.testnet.alephium.org` for testnet with explorer backend v1.12.X, deprecated ([Test](https://backend-v112.testnet.alephium.org/infos))


### PR DESCRIPTION
v20 endpoints will remain the only ones after Leman upgrade