### PR TITLE
Fix Duplicate Redirects in Docusaurus Config

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -238,10 +238,6 @@ const config = {
             from: "/wallet/desktop-wallet-guide",
             to: "/wallet/desktop-wallet/overview",
           },
-          {
-            from: "/wallet/Desktop-Wallet-Guide",
-            to: "/wallet/desktop-wallet/overview",
-          },
         ],
       },
     ],


### PR DESCRIPTION
### Description
This PR removes a duplicate redirect entry in docusaurus.config.js to fix a build error caused by conflicting file creation. The error encountered during the build process is as follows:

```
[ERROR] Redirect file creation error for "build/wallet/desktop-wallet-guide/index.html".
[ERROR] Unable to build website for locale en.
[ERROR] Error: EEXIST: file already exists, open 'build/wallet/desktop-wallet-guide/index.html'
```
### Changes
Removed the duplicate redirect from /wallet/Desktop-Wallet-Guide to /wallet/desktop-wallet/overview.
