### PR TITLE
Update Bridge Doc Redirect

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -234,7 +234,7 @@ const config = {
             to: "/dapps/concepts/asset-permission-system",
           },
           {
-            from: "/The%20Bridge",
+            from: "/The Bridge",
             to: "/infrastructure/the-bridge"
           },
           {


### PR DESCRIPTION
Bridge doc redirect doesn't seem to work. The redirect plugin doesn't allow testing locally, I suspect it doesn't like the URL encoding for space.