### PR TITLE
Fix Algolia appId and apiKey

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -146,8 +146,8 @@ const config = {
         additionalLanguages: ["bash", "rust"],
       },
       algolia: {
-        appId: "FZTHKMBSEE",
-        apiKey: "3465cd1cf18d2515a57fcd6dbdcc775b",
+        appId: "9BBPVRH6NS",
+        apiKey: "ac80b7ba74123ae9265eac5e84576e37",
         indexName: "alephium",
       },
       zoom: {


### PR DESCRIPTION
Received two appId and apiKey from the team. The previous (manually created) one doesn't seem to work.
This one is the one from the Algolia integration form. 