### PR TITLE
Use dapp templates

### DIFF
--- a/docs/dapps/ecosystem.md
+++ b/docs/dapps/ecosystem.md
@@ -10,6 +10,12 @@ sidebar_label: Ecosystem
 - [Local Devnet](https://github.com/alephium/alephium-stack#devnet) (explorer included)
 - Public APIs for mainnet and testnet are documented [here](/infrastructure/public-services#api-aliases)
 
+## Templates
+
+- [Node.js template](https://github.com/alephium/nodejs-dapp-template)
+- [Next.js template](https://github.com/alephium/nextjs-dapp-template)
+- [React template](https://github.com/alephium/react-dapp-template)
+
 ## dApp SDK
 - [@alephium/web3](https://www.npmjs.com/package/@alephium/web3)
 - [@alephium/web3-wallet](https://www.npmjs.com/package/@alephium/web3-wallet) 

--- a/docs/dapps/index.md
+++ b/docs/dapps/index.md
@@ -12,6 +12,16 @@ SDK](/sdk/getting-started), which offers powerful tools to
 interact with the blockchain and a developer friendly framework
 for compiling, testing and deploying smart contracts.
 
+## Getting Started with a template
+
+The easiest way to get started with building dApps on Alephium is to use one of the available templates.
+
+* [Node.js template](https://github.com/alephium/nodejs-dapp-template): A simple faucet dApp built with Node.js.
+* [Next.js template](https://github.com/alephium/nextjs-dapp-template): A simple faucet dApp built with Next.js.
+* [React template](https://github.com/alephium/react-dapp-template): A simple react template.
+
+## Concepts and Standards
+
 Here, you'll find information on high-level
 [concepts](/dapps/concepts/overview) and
 [standards](/dapps/standards/fungible-tokens), as well as practical

--- a/docs/dapps/tutorials/quick-start.md
+++ b/docs/dapps/tutorials/quick-start.md
@@ -29,7 +29,7 @@ If you experience slowness with `npm` and `npx`, consider give
 To create the tutorial project, open a new terminal and run:
 
 ```shell
-npx @alephium/cli@latest init alephium-tutorial
+git clone https://github.com/alephium/nodejs-dapp-template alephium-tutorial
 ```
 
 This will create a new directory `alephium-tutorial` and initialize a sample project inside that directory.
@@ -51,7 +51,7 @@ through REST endpoints.
 Next, change the workspace to the tutorial project:
 
 ```
-cd alephium-tutorial
+cd alephium-tutorial && npm install
 ```
 
 In the `contracts/` folder, you will find `token.ral` and `withdraw.ral`:
@@ -153,7 +153,7 @@ TxScript Withdraw(token: TokenFaucet, amount: U256) {
 To compile your contracts, run:
 
 ```
-npx @alephium/cli@latest compile
+npm run compile
 ```
 
 The compiled artifacts are in the `artifacts` directory. This command also generates Typescript code based on the compiled artifacts, which is in the `artifacts/ts` directory. You can use the generated Typescript code to interact with the alephium blockchain more conveniently.
@@ -215,12 +215,6 @@ You can run the tests with:
 npm run test
 ```
 
-or
-
-```
-npx @alephium/cli@latest test
-```
-
 ## Deploy your contract
 
 To deploy the contract, use Alephium CLI and a deployment script `scripts/0_deploy_faucet.ts`:
@@ -266,13 +260,13 @@ export default deployFaucet
 You can run the deployment script with:
 
 ```
-npx @alephium/cli@latest deploy
+npm run deploy
 ```
 
 This will deploy the token faucet to group 0 of devnet. To deploy on testnet (or any other network), update your `alephium.config.ts` and use the `--network` option:
 
 ```
-npx @alephium/cli@latest deploy --network testnet
+npm run deploy --network testnet
 ```
 
 ## Interact with the deployed contract

--- a/package.json
+++ b/package.json
@@ -41,5 +41,6 @@
   "devDependencies": {
     "node-fetch": "^2.6.7",
     "prettier": "2.6.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
 }


### PR DESCRIPTION
It's much easier to improve and maintain the templates with standalone repositories. I also plan to add more templates, e.g. for vite.js, remix.

I will deprecate the `cli init` command gradually.